### PR TITLE
Poison System Directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if (NPF_32BIT AND NOT MSVC)
     set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${NPF_32BIT_FLAG})
 endif()
 
+if (NOT MSVC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-poison-system-directories")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-poison-system-directories")
+endif()
+
 ################ CppUTest
 
 include(ExternalProject)
@@ -61,7 +66,7 @@ add_dependencies(libCppUTestExt CppUTest_external)
 
 ################ Common compile flags
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 if (MSVC)
     set(nanoprintf_common_flags /W4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NPF_32BIT AND NOT MSVC)
     set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${NPF_32BIT_FLAG})
 endif()
 
-if (NOT MSVC)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-poison-system-directories")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-poison-system-directories")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,7 @@ function(npf_test name files)
             -Wno-old-style-cast     # C style casts are ok
             -Wno-format
             -Wno-format-pedantic
-            -Wno-format-nonliteral
-            -std=c++11)
+            -Wno-format-nonliteral)
     endif()
 
     if (is_clang GREATER_EQUAL 0)

--- a/build.py
+++ b/build.py
@@ -15,7 +15,6 @@ SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 NINJA_URL = 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/{}'
 CMAKE_URL = 'https://cmake.org/files/v3.14/{}'
 
-
 def parse_args():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
@@ -124,6 +123,7 @@ def configure_cmake(cmake_exe, ninja, args):
                   SCRIPT_PATH,
                   '-G',
                   'Ninja',
+                  '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
                   '-DCMAKE_MAKE_PROGRAM={}'.format(ninja),
                   '-DCMAKE_BUILD_TYPE={}'.format(args.cfg),
                   '-DNPF_32BIT={}'.format('ON' if args.build_32_bit else 'OFF')]

--- a/conformance_tests/test_conformance.cpp
+++ b/conformance_tests/test_conformance.cpp
@@ -80,6 +80,8 @@ TEST(conformance, Strings) {
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     CheckConformance("       two", "%10s", "two");
+    CheckConformance("B---       E", "B%-10sE", "---");
+    CheckConformance("B       ---E", "B%10sE", "---");
 #endif
 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1

--- a/unit_tests/test_parse_format_spec.cpp
+++ b/unit_tests/test_parse_format_spec.cpp
@@ -403,6 +403,13 @@ TEST(npf__parse_format_spec, cClearsLeadingZero) {
     CHECK_EQUAL(0, spec.leading_zero_pad);
 }
 
+TEST(npf__parse_format_spec, StringLeftJustifyFieldWidth) {
+    CHECK_EQUAL(5, npf__parse_format_spec("%-15s", &spec));
+    CHECK_EQUAL(NPF_FMT_SPEC_CONV_STRING, spec.conv_spec);
+    CHECK_EQUAL(1, spec.left_justified);
+    CHECK_EQUAL(15, spec.field_width);
+}
+
 TEST(npf__parse_format_spec, i) {
     CHECK_EQUAL(2, npf__parse_format_spec("%i", &spec));
     CHECK_EQUAL(NPF_FMT_SPEC_CONV_SIGNED_INT, spec.conv_spec);


### PR DESCRIPTION
Small fixes:

- Disable the `poison-system-directories` warning; something in CppUTest triggers it but we're not cross-compiling and it's only for the test harness stuff, so just shut it up.

- Emit a compilation database for editors / tools that enjoy it.

- Explicit test for left-justified field-width strings (e.g. `%-10s`), there was a user report but I couldn't repo. Nice to have tests either way.