### PR TITLE
Use GitHub Container Registry and `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-image:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-image:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-image:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -69,9 +69,11 @@ jobs:
 
   macos:
     runs-on: macos-latest
+
     strategy:
       matrix:
         configuration: [Debug, Release]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.x
@@ -80,12 +82,15 @@ jobs:
           python-version: '3.x'
       - name: Build
         run: ./b --cfg ${{ matrix.configuration }} -v
+
   win:
     runs-on: windows-latest
+
     strategy:
       matrix:
         architecture: [32, 64]
         configuration: [Debug, Release]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.x

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -6,29 +6,38 @@ on:
   schedule:
     - cron: '0 2 * * 0'  # Weekly
 
+permissions:
+  packages:read
+
 jobs:
   pylint:
     runs-on: ubuntu-latest
+
     container:
-      image: docker.pkg.github.com/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-images/docker-image:latest
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.PACKAGE_READ_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Pylint build.py
         run: python3 -m pylint build.py
+
   linux-gcc:
     runs-on: ubuntu-latest
+
     container:
-      image: docker.pkg.github.com/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-images/docker-image:latest
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.PACKAGE_READ_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     strategy:
       matrix:
         configuration: [Debug, Release]
         architecture: ['', --build-32-bit]
+
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -36,16 +45,20 @@ jobs:
           CC: /usr/bin/gcc
           CXX: /usr/bin/g++
         run: ./b --cfg ${{ matrix.configuration }} ${{ matrix.architecture }} -v
+
   linux-clang:
     runs-on: ubuntu-latest
+
     container:
-      image: docker.pkg.github.com/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-images/docker-image:latest
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.PACKAGE_READ_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     strategy:
       matrix:
         configuration: [Debug, Release]
+
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -53,6 +66,7 @@ jobs:
           CC: /usr/bin/clang
           CXX: /usr/bin/clang++
         run: ./b --cfg ${{ matrix.configuration }} -v
+
   macos:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 2 * * 0'  # Weekly
 
 permissions:
-  packages:read
+  packages: read
 
 jobs:
   pylint:


### PR DESCRIPTION
This PR just moves the CI over to the new ghcr.io GitHub Container Registry and uses the new dynamic `GITHUB_TOKEN` auth token. This way I can delete the PAT that impersonates me every time we build, should also help with CI for any pull requests that come in.