### PR TITLE
README: "Paland's printf" instead of "printf"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ nanoprintf is statically configurable so users can find a balance between size, 
 
 [tinyprintf](https://github.com/cjlano/tinyprintf) doesn't print floating point values.
 
-"[printf](https://github.com/mpaland/printf)" defines the actual standard library `printf` symbol, which isn't always what you want. It stores the final converted string (with padding and precision) in a temporary buffer, which makes supporting longer strings more costly. It also doesn't support the `%n` "write-back" specifier.
+Paland's "[printf](https://github.com/mpaland/printf)" defines the actual standard library `printf` symbol, which isn't always what you want. It stores the final converted string (with padding and precision) in a temporary buffer, which makes supporting longer strings more costly. It also doesn't support the `%n` "write-back" specifier.
 
 Also, no embedded-friendly printf projects that I could find are both in the public domain *and* have single-file implementations.
 


### PR DESCRIPTION
Paland's printf is quite popular in the embedded world. I just added his last name so that: 1) it's clearer what "printf" the README is referring to; 2) it's more googleable (e.g., when someone searches for "tinyprintf vs Paland printf")