### PR TITLE
add -Wswitch-enum and tidy up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ else()
       -Wswitch-enum
       -Wswitch-default
       -Wno-padded
+      -Wno-covered-switch-default
       -Wno-unused-function)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,9 @@ else()
       -Werror
       -Wconversion
       -Wsign-conversion
+      -Wswitch-enum
       -Wswitch-default
       -Wno-padded
-      -Wno-covered-switch-default
       -Wno-unused-function)
 endif()
 

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -511,6 +511,13 @@ int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec) {
         out_spec->precision = 6;
         break;
 #endif
+      case NPF_FMT_SPEC_CONV_PERCENT:
+      case NPF_FMT_SPEC_CONV_CHAR:
+      case NPF_FMT_SPEC_CONV_STRING:
+      case NPF_FMT_SPEC_CONV_POINTER:
+#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
+      case NPF_FMT_SPEC_CONV_WRITEBACK:
+#endif
       default:
         break;
     }


### PR DESCRIPTION
Reasonable compilation settings were giving "unhandled case in switch" warnings. This PR silences the warnings and fixes the build config that was letting it through.