### PR TITLE
New MSVC support, license update, tiny simplification

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,10 @@ structure is to make nanoprintf as consumable as possible in as many
 environments / countries / companies as possible without encumbering
 users.
 
+This license applies to all of the nanoprintf source code, build code,
+and tests, with the explicit exception of doctest.h, which exists under
+its own license and is included in this repository.
+
 The text of the two licenses follows below:
 
 ============================== UNLICENSE ==============================

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -751,12 +751,12 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
     switch (fs.conv_spec) {
       case NPF_FMT_SPEC_CONV_PERCENT:
         *cbuf = '%';
-        ++cbuf_len;
+        cbuf_len = 1;
         break;
 
       case NPF_FMT_SPEC_CONV_CHAR:
         *cbuf = (char)va_arg(args, int);
-        ++cbuf_len;
+        cbuf_len = 1;
         break;
 
       case NPF_FMT_SPEC_CONV_STRING: {

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -162,13 +162,14 @@ NPF_VISIBILITY int npf_vpprintf(
   #pragma warning(push)
   #pragma warning(disable:4514) // unreferenced inline function removed
   #pragma warning(disable:4505) // unreferenced function removed
-  #pragma warning(disable:4820) // padding after data member
-  #pragma warning(disable:5039) // extern "C" throw
-  #pragma warning(disable:5045) // spectre mitigation
   #pragma warning(disable:4701) // possibly uninitialized
   #pragma warning(disable:4706) // assignment in conditional
   #pragma warning(disable:4710) // not inlined
   #pragma warning(disable:4711) // selected for inline
+  #pragma warning(disable:4820) // padding after data member
+  #pragma warning(disable:5039) // extern "C" throw
+  #pragma warning(disable:5045) // spectre mitigation
+  #pragma warning(disable:5262) // implicit switch fall-through
 #endif
 
 #if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1) || \

--- a/tests/conformance.cc
+++ b/tests/conformance.cc
@@ -7,6 +7,7 @@
   #pragma warning(disable:5039) // extern "c" throw
   #pragma warning(disable:4710) // function not inlined
   #pragma warning(disable:4711) // selected for inline
+  #pragma warning(disable:5264) // const variable not used (shut up doctest)
 #endif
 
 #define NANOPRINTF_IMPLEMENTATION

--- a/tests/doctest_main.cc
+++ b/tests/doctest_main.cc
@@ -1,6 +1,7 @@
 #ifdef _MSC_VER
   #pragma warning(disable:5246) // initialization of subobject needs braces
   #pragma warning(disable:5262) // implicit switch fall-through
+  #pragma warning(disable:5264) // unused const variable
 #endif
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN

--- a/tests/doctest_main.cc
+++ b/tests/doctest_main.cc
@@ -1,5 +1,6 @@
 #ifdef _MSC_VER
   #pragma warning(disable:5246) // initialization of subobject needs braces
+  #pragma warning(disable:5262) // implicit switch fall-through
 #endif
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN

--- a/tests/unit_nanoprintf.h
+++ b/tests/unit_nanoprintf.h
@@ -30,6 +30,7 @@
   #pragma warning(disable:4711) // function was inlined
   #pragma warning(disable:4514) // unreferenced inline function has been removed
   #pragma warning(disable:5039) // could throw inside extern c function
+  #pragma warning(disable:5264) // const variable not used (shut up doctest)
 #endif
 
 #include "doctest.h"


### PR DESCRIPTION
1. Support MSVC 17, which doesn't compile its own STL cleanly at /Wall
2. Update the license file to explicitly exclude the doctest.h amalgamation from the 0bsd/unlicense; it's MIT.
3. Tiny little cleanup; 1-character format strings `%` and `c` didn't need to load/inc/store cbuf_len, just store `1`.