### PR TITLE
Issue #246. Fixes formatting floats via gcc-avr.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 * [Dino Dai Zovi](https://github.com/ddz)
 * [Shang Yuanchun](https://github.com/ideal)
 * [Shreyas Balakrishna](https://github.com/shreyasbharath)
+* [Jim Keener](https://github.com/jimktrains)

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -512,7 +512,7 @@ int npf_fsplit_abs(float f, uint64_t *out_int_part, uint64_t *out_frac_part,
 
   if (exponent >= (64 - NPF_MANTISSA_BITS)) { return 0; } // value is out of range
 
-  uint32_t const implicit_one = 1u << NPF_MANTISSA_BITS;
+  uint32_t const implicit_one = ((uint32_t)1) << NPF_MANTISSA_BITS;
   uint32_t const mantissa = f_bits & (implicit_one - 1);
   uint32_t const mantissa_norm = mantissa | implicit_one;
 


### PR DESCRIPTION
On platforms that have a 16-bit `unsigned int`, the `implicit_one` constant is mis-calculated. Explicitly casting this to a `uint32_t` fixes the issue.

Running tests via `./b` has all test passing.