### PR TITLE
Fix for accessing string content when precision is 0.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 * [Shang Yuanchun](https://github.com/ideal)
 * [Shreyas Balakrishna](https://github.com/shreyasbharath)
 * [Jim Keener](https://github.com/jimktrains)
+* [Dean T](https://github.com/deanoburrito)

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -744,7 +744,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
         cbuf = va_arg(args, char *);
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
         for (char const *s = cbuf;
-             s && *s && ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec));
+             ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec)) && *s;
              ++s, ++cbuf_len);
 #else
         for (char const *s = cbuf; *s; ++s, ++cbuf_len); // strlen

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -744,7 +744,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
         cbuf = va_arg(args, char *);
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
         for (char const *s = cbuf;
-             *s && ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec));
+             s && *s && ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec));
              ++s, ++cbuf_len);
 #else
         for (char const *s = cbuf; *s; ++s, ++cbuf_len); // strlen

--- a/tests/unit_vpprintf.cc
+++ b/tests/unit_vpprintf.cc
@@ -78,6 +78,11 @@ TEST_CASE("npf_vpprintf") {
     REQUIRE(r.String() == std::string{"abcdefgh"});
   }
 
+  SUBCASE("string precision zero null pointer") {
+    REQUIRE(npf_pprintf(r.PutC, &r, "%.0s", nullptr) == 0);
+    REQUIRE(r.String() == std::string{""});
+  }
+
   SUBCASE("signed int zero") {
     REQUIRE(npf_pprintf(r.PutC, &r, "%i", 0) == 1);
     REQUIRE(r.String() == std::string{"0"});

--- a/tests/unit_vpprintf.cc
+++ b/tests/unit_vpprintf.cc
@@ -10,11 +10,12 @@
   #if NANOPRINTF_CLANG
     #pragma GCC diagnostic ignored "-Wformat-pedantic"
     #pragma GCC diagnostic ignored "-Wold-style-cast"
+  #else
+    #pragma GCC diagnostic ignored "-Wformat-overflow"
   #endif
   #pragma GCC diagnostic ignored "-Wformat"
   #pragma GCC diagnostic ignored "-Wformat-zero-length"
   #pragma GCC diagnostic ignored "-Wformat-security"
-  #pragma GCC diagnostic ignored "-Wformat-overflow"
 #endif
 
 struct Recorder {

--- a/tests/unit_vpprintf.cc
+++ b/tests/unit_vpprintf.cc
@@ -14,6 +14,7 @@
   #pragma GCC diagnostic ignored "-Wformat"
   #pragma GCC diagnostic ignored "-Wformat-zero-length"
   #pragma GCC diagnostic ignored "-Wformat-security"
+  #pragma GCC diagnostic ignored "-Wformat-overflow"
 #endif
 
 struct Recorder {


### PR DESCRIPTION
Hey there,
First of all thanks for nanoprintf - it's been a great addition to a few of my projects.

I came across an issue (or rather unexpected behaviour) when using it in my kernel, specifically when formatting a string as `%.*s` and passing 0 as the precision. As expected this will write 0 characters, but the pointer for the string content is still de-referenced in the loop condition (to check for a null terminator). This is fine if the pointer for the string content is valid, but if the pointer is null it results in null deref.

It might sound silly wanting to write a string with a precision of 0 and null for the data, but my use case is printing human-readable debug data passed from a device driver (where strings are represented with a data pointer + length). In this case a driver might not want to provide anything so it sets the length to 0 and data pointer to null. I could (and probably should) check for this across kernel/driver boundaries, but I feel it'd be nice to have this in nanoprintf as well.

Thanks,
Dean.