### PR TITLE
Optimize format specifier parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ arm-none-eabi-nm --print-size --size-sort npf.o
 00000046 00000002 t npf_bufputc_nop
 00000048 00000010 t npf_putc_cnt
 00000032 00000014 t npf_bufputc
-00000274 00000016 T npf_pprintf
-000002d0 00000016 T npf_snprintf
+00000270 00000016 T npf_pprintf
+000002cc 00000016 T npf_snprintf
 00000000 00000032 t npf_utoa_rev
-0000028a 00000046 T npf_vsnprintf
-00000058 0000021c T npf_vpprintf
-Total size: 0x2e6 (742) bytes
+00000286 00000046 T npf_vsnprintf
+00000058 00000218 T npf_vpprintf
+Total size: 0x2e2 (738) bytes
 
 Configuration "Binary":
 arm-none-eabi-gcc -c -x c -Os -I/__w/nanoprintf/nanoprintf -o npf.o -mcpu=cortex-m0 -DNANOPRINTF_IMPLEMENTATION -DNANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=0 -
@@ -198,12 +198,12 @@ arm-none-eabi-nm --print-size --size-sort npf.o
 00000046 00000002 t npf_bufputc_nop
 00000048 00000010 t npf_putc_cnt
 00000032 00000014 t npf_bufputc
-000002b4 00000016 T npf_pprintf
-00000310 00000016 T npf_snprintf
+000002a8 00000016 T npf_pprintf
+00000304 00000016 T npf_snprintf
 00000000 00000032 t npf_utoa_rev
-000002ca 00000046 T npf_vsnprintf
-00000058 0000025c T npf_vpprintf
-Total size: 0x326 (806) bytes
+000002be 00000046 T npf_vsnprintf
+00000058 00000250 T npf_vpprintf
+Total size: 0x31a (794) bytes
 
 Configuration "Field Width + Precision":
 arm-none-eabi-gcc -c -x c -Os -I/__w/nanoprintf/nanoprintf -o npf.o -mcpu=cortex-m0 -DNANOPRINTF_IMPLEMENTATION -DNANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=0 -
@@ -211,12 +211,12 @@ arm-none-eabi-nm --print-size --size-sort npf.o
 00000046 00000002 t npf_bufputc_nop
 00000048 00000010 t npf_putc_cnt
 00000032 00000014 t npf_bufputc
-000004f8 00000016 T npf_pprintf
-00000554 00000016 T npf_snprintf
+000004fe 00000016 T npf_pprintf
+0000055c 00000016 T npf_snprintf
 00000000 00000032 t npf_utoa_rev
-0000050e 00000046 T npf_vsnprintf
-00000058 000004a0 T npf_vpprintf
-Total size: 0x56a (1386) bytes
+00000514 00000048 T npf_vsnprintf
+00000058 000004a6 T npf_vpprintf
+Total size: 0x572 (1394) bytes
 
 Configuration "Field Width + Precision + Binary":
 arm-none-eabi-gcc -c -x c -Os -I/__w/nanoprintf/nanoprintf -o npf.o -mcpu=cortex-m0 -DNANOPRINTF_IMPLEMENTATION -DNANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=0 -
@@ -224,12 +224,12 @@ arm-none-eabi-nm --print-size --size-sort npf.o
 00000046 00000002 t npf_bufputc_nop
 00000048 00000010 t npf_putc_cnt
 00000032 00000014 t npf_bufputc
-0000055a 00000016 T npf_pprintf
-000005b8 00000016 T npf_snprintf
+00000560 00000016 T npf_pprintf
+000005bc 00000016 T npf_snprintf
 00000000 00000032 t npf_utoa_rev
-00000570 00000048 T npf_vsnprintf
-00000058 00000502 T npf_vpprintf
-Total size: 0x5ce (1486) bytes
+00000576 00000046 T npf_vsnprintf
+00000058 00000508 T npf_vpprintf
+Total size: 0x5d2 (1490) bytes
 
 Configuration "Float":
 arm-none-eabi-gcc -c -x c -Os -I/__w/nanoprintf/nanoprintf -o npf.o -mcpu=cortex-m0 -DNANOPRINTF_IMPLEMENTATION -DNANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=1 -DNANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=0 -

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -199,14 +199,14 @@ NPF_VISIBILITY int npf_vpprintf(
 
 #if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1) || \
     (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
-typedef enum {
+enum {
   NPF_FMT_SPEC_OPT_NONE,
   NPF_FMT_SPEC_OPT_LITERAL,
   NPF_FMT_SPEC_OPT_STAR,
-} npf_fmt_spec_opt_t;
+};
 #endif
 
-typedef enum {
+enum {
   NPF_FMT_SPEC_LEN_MOD_NONE,
   NPF_FMT_SPEC_LEN_MOD_SHORT,       // 'h'
   NPF_FMT_SPEC_LEN_MOD_LONG_DOUBLE, // 'L'
@@ -218,9 +218,9 @@ typedef enum {
   NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET,     // 'z'
   NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT,  // 't'
 #endif
-} npf_format_spec_length_modifier_t;
+};
 
-typedef enum {
+enum {
   NPF_FMT_SPEC_CONV_NONE,
   NPF_FMT_SPEC_CONV_PERCENT,      // '%'
   NPF_FMT_SPEC_CONV_CHAR,         // 'c'
@@ -242,24 +242,24 @@ typedef enum {
   NPF_FMT_SPEC_CONV_FLOAT_SHORTEST, // 'g', 'G'
   NPF_FMT_SPEC_CONV_FLOAT_HEX,      // 'a', 'A'
 #endif
-} npf_format_spec_conversion_t;
+};
 
 typedef struct npf_format_spec {
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
   int field_width;
-  uint8_t field_width_opt; // npf_fmt_spec_opt_t
+  uint8_t field_width_opt;
   char left_justified;   // '-'
   char leading_zero_pad; // '0'
 #endif
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
   int prec;
-  uint8_t prec_opt;        // npf_fmt_spec_opt_t
+  uint8_t prec_opt;
 #endif
   char prepend;          // ' ' or '+'
   char alt_form;         // '#'
   char case_adjust;      // 'a' - 'A'
-  uint8_t length_modifier; // npf_format_spec_length_modifier_t
-  uint8_t conv_spec;       // npf_format_spec_conversion_t
+  uint8_t length_modifier;
+  uint8_t conv_spec;
 } npf_format_spec_t;
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 0
@@ -419,7 +419,7 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
     case 'u': if (tmp_conv == NPF_FMT_SPEC_CONV_NONE) { tmp_conv = NPF_FMT_SPEC_CONV_UNSIGNED_INT; }
     case 'X': if (tmp_conv == NPF_FMT_SPEC_CONV_NONE) { out_spec->case_adjust = 0; }
     case 'x': if (tmp_conv == NPF_FMT_SPEC_CONV_NONE) { tmp_conv = NPF_FMT_SPEC_CONV_HEX_INT; }
-      out_spec->conv_spec = tmp_conv;
+      out_spec->conv_spec = (uint8_t)tmp_conv;
 #if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1) && \
     (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
       if (out_spec->prec_opt != NPF_FMT_SPEC_OPT_NONE) { out_spec->leading_zero_pad = 0; }


### PR DESCRIPTION
This one reduces the number of assignment operations and does comparisons against `NPF_FMT_SPEC_OPT_NONE`, which equals zero. On AVR and PIC32 it manages to decrease the binary size by a whopping 96 and 128 bytes respectively. Though even more surprisingly it also somehow manages to increase the binary size by 16 bytes on my Cortex-M7 build.