### PR TITLE
Freestanding improvements (ssize_t definition and inttypes.h usage)

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -277,7 +277,9 @@ typedef struct npf_bufputc_ctx {
 } npf_bufputc_ctx_t;
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-  #ifdef _MSC_VER
+  #ifdef NANOPRINTF_SSIZE_TYPE_OVERRIDE
+    typedef NANOPRINTF_SSIZE_TYPE_OVERRIDE ssize_t;
+  #elif defined(_MSC_VER)
     #include <BaseTsd.h>
     typedef SSIZE_T ssize_t;
   #else

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -64,7 +64,6 @@ NPF_VISIBILITY int npf_vpprintf(
 
 #include <limits.h>
 #include <stdint.h>
-#include <inttypes.h>
 
 // The conversion buffer must fit at least UINT64_MAX in octal format with the leading '0'.
 #ifndef NANOPRINTF_CONVERSION_BUFFER_SIZE
@@ -277,14 +276,10 @@ typedef struct npf_bufputc_ctx {
 } npf_bufputc_ctx_t;
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-  #ifdef NANOPRINTF_SSIZE_TYPE_OVERRIDE
-    typedef NANOPRINTF_SSIZE_TYPE_OVERRIDE ssize_t;
-  #elif defined(_MSC_VER)
-    #include <BaseTsd.h>
-    typedef SSIZE_T ssize_t;
-  #else
-    #include <sys/types.h>
+  #if PTRDIFF_MAX != SIZE_MAX / 2
+    #error ptrdiff_t and size_t must be the same size
   #endif
+  typedef ptrdiff_t ssize_t;
 #endif
 
 #ifdef _MSC_VER

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -277,9 +277,9 @@ typedef struct npf_bufputc_ctx {
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
   //compile-time assertion
-  typedef char size_t_and_ptrdiff_t_have_same_size[(sizeof(size_t) == sizeof(ptrdiff_t)) ? 1 : -1];
+  typedef char npf_ssize_t_and_ptrdiff_t_have_same_size[(sizeof(size_t) == sizeof(ptrdiff_t)) ? 1 : -1];
 
-  typedef ptrdiff_t ssize_t;
+  typedef ptrdiff_t npf_ssize_t;
 #endif
 
 #ifdef _MSC_VER
@@ -828,7 +828,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           NPF_EXTRACT(LARGE_LONG_LONG, long long, long long);
           NPF_EXTRACT(LARGE_INTMAX, intmax_t, intmax_t);
-          NPF_EXTRACT(LARGE_SIZET, ssize_t, ssize_t);
+          NPF_EXTRACT(LARGE_SIZET, npf_ssize_t, npf_ssize_t);
           NPF_EXTRACT(LARGE_PTRDIFFT, ptrdiff_t, ptrdiff_t);
 #endif
           default: break;

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -276,9 +276,9 @@ typedef struct npf_bufputc_ctx {
 } npf_bufputc_ctx_t;
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-  #if PTRDIFF_MAX != SIZE_MAX / 2
-    #error ptrdiff_t and size_t must be the same size
-  #endif
+  //compile-time assertion
+  typedef char size_t_and_ptrdiff_t_have_same_size[(sizeof(size_t) == sizeof(ptrdiff_t)) ? 1 : -1];
+
   typedef ptrdiff_t ssize_t;
 #endif
 


### PR DESCRIPTION
Hey again!

The issue is that when using large format specifiers nanoprintf makes use of `ssize_t`, and on non-msvc compilers that means including <sys/types.h>. This header isn't freestanding (as per the C spec), and so its existence can't be relied upon - and it often results in a compilation failure for freestanding projects. So apparently I'd patched around this in my kernel project a long time ago and forgotten, but it popped up recently when getting someone else setup with nanoprintf. So here I am opening a PR haha.

This PR is my proposed solution, but let me know what you think. I imagine if you were to merge this you'd want this documented in the readme as well - I'm also happy to do that :)

This isn't addressed here, but the other issue with compiling nanoprintf as freestanding was its use of `inttypes.h` - again something I'd patched out for my project, but not included any replacement for. Is this header still used or could it be removed?

Thanks,
Dean.