### PR TITLE
Fix precision padding for float specifiers

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -977,7 +977,10 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
     if (fs.conv_spec != NPF_FMT_SPEC_CONV_STRING) {
 #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
       // float precision is after the decimal point
-      if (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_DEC)
+      if ((fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_DEC) &&
+          (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SCI) &&
+          (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SHORTEST) &&
+          (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_HEX))
 #endif
       { prec_pad = npf_max(0, fs.prec - cbuf_len); }
     }

--- a/tests/conformance.cc
+++ b/tests/conformance.cc
@@ -471,6 +471,10 @@ TEST_CASE("conformance to system printf") {
     require_conform(" inf", "%4f", (double)INFINITY);
 #endif // NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS
     require_conform("inf", "%.100f", (double)INFINITY);
+    require_conform("inf", "%.10f", (double)INFINITY);
+    require_conform("inf", "%.10e", (double)INFINITY);
+    require_conform("inf", "%.10g", (double)INFINITY);
+    require_conform("inf", "%.10a", (double)INFINITY);
     require_conform("INF", "%F", (double)INFINITY);
     require_conform("0.000000", "%f", 0.0);
     require_conform("0.00", "%.2f", 0.0);


### PR DESCRIPTION
Fixes the float formatting issue discovered by @josesimoes in #273.
Example of failing code:
```C
npf_snprintf(..., ..., "%.5g", (double)INFINITY);
```
Output: `00inf`