### PR TITLE
hoist field width initialization to avoid LTO warning

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -312,12 +312,12 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
   }
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
+  out_spec->field_width = 0;
   out_spec->field_width_opt = NPF_FMT_SPEC_OPT_NONE;
   if (*cur == '*') {
     out_spec->field_width_opt = NPF_FMT_SPEC_OPT_STAR;
     ++cur;
   } else {
-    out_spec->field_width = 0;
     while ((*cur >= '0') && (*cur <= '9')) {
       out_spec->field_width_opt = NPF_FMT_SPEC_OPT_LITERAL;
       out_spec->field_width = (out_spec->field_width * 10) + (*cur++ - '0');


### PR DESCRIPTION
The `field_width` member of the format spec structure was only being initialized in a code path where it was known to be used in the future. This confuses GCC's always-flaky `maybe-uninitialized` warning logic, which is disabled in `nanoprintf.h` but seems to persist due to a GCC bug where LTO ignores warning flags.

So, this PR just moves `field_width` initialization to the common path.