### PR TITLE
Fix signed char conversion.

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -821,7 +821,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           NPF_EXTRACT(NONE, int, int);
           NPF_EXTRACT(SHORT, short, int);
           NPF_EXTRACT(LONG_DOUBLE, int, int);
-          NPF_EXTRACT(CHAR, char, int);
+          NPF_EXTRACT(CHAR, signed char, int);
           NPF_EXTRACT(LONG, long, long);
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           NPF_EXTRACT(LARGE_LONG_LONG, long long, long long);


### PR DESCRIPTION
From [cppreference](https://en.cppreference.com/w/cpp/language/types)
> The signedness of char depends on the compiler and the target platform: the defaults for ARM and PowerPC are typically unsigned, the defaults for x86 and x64 are typically signed.

Also from [ACLE](https://arm-software.github.io/acle/main/acle.html#data-types)
> Plain char is unsigned, as specified in the ABI [AAPCS] and [AAPCS64] (7.1.1).

This fixes the failed test on `AARCH64` for `conformance.cc`
```c
TEST_CASE("conformance to system printf") {
  ...
  SUBCASE("signed int") {
    ...
    require_conform("-128", "%hhi", 128);  // print 128 instead of -128 on aarch64
    ...
  }
  ...
}
```

