### PR TITLE
CI: arm64 linux

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -65,8 +65,8 @@ jobs:
           CXX: /usr/bin/clang++
         run: ./b --arch ${{ matrix.architecture }} --${{ matrix.sanitizer }} --paland -v
 
-  linux-gcc:
-    runs-on: ["${{ matrix.runner }}"]
+  linux-x64:
+    runs-on: ubuntu-latest
 
     container:
       image: ghcr.io/charlesnicholson/docker-image:latest
@@ -76,9 +76,9 @@ jobs:
 
     strategy:
       matrix:
+        compiler: [gcc, clang]
         configuration: [Debug, Release]
         architecture: [32, 64]
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -86,24 +86,18 @@ jobs:
           submodules: recursive
       - name: Build
         env:
-          CC: /usr/bin/gcc
-          CXX: /usr/bin/g++
+          CC: ${{ compiler }}
+          CXX: ${{ compiler }}++
         run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
 
-  linux-clang:
-    runs-on: ["${{ matrix.runner }}"]
-
-    container:
-      image: ghcr.io/charlesnicholson/docker-image:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+  linux-arm64:
+    runs-on: ubuntu-24.04-arm
 
     strategy:
       matrix:
+        compiler: [gcc, clang]
         configuration: [Debug, Release]
         architecture: [32, 64]
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -111,8 +105,8 @@ jobs:
           submodules: recursive
       - name: Build
         env:
-          CC: /usr/bin/clang
-          CXX: /usr/bin/clang++
+          CC: ${{ compiler }}
+          CXX: ${{ compiler }}++
         run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
 
   macos:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -79,6 +79,13 @@ jobs:
         compiler: [gcc, clang]
         configuration: [Debug, Release]
         architecture: [32, 64]
+        include:
+        - compiler: gcc
+          cc: gcc
+          cxx: g++
+        - compiler: clang
+          cc: clang
+          cxx: clang++
 
     steps:
       - uses: actions/checkout@v4
@@ -86,8 +93,8 @@ jobs:
           submodules: recursive
       - name: Build
         env:
-          CC: ${{ matrix.compiler }}
-          CXX: ${{ matrix.compiler }}++
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
 
   linux-arm64:
@@ -97,6 +104,14 @@ jobs:
       matrix:
         compiler: [gcc, clang]
         configuration: [Debug, Release]
+        architecture: [32, 64]
+        include:
+        - compiler: gcc
+          cc: gcc
+          cxx: g++
+        - compiler: clang
+          cc: clang
+          cxx: clang++
 
     steps:
       - uses: actions/checkout@v4
@@ -104,8 +119,8 @@ jobs:
           submodules: recursive
       - name: Build
         env:
-          CC: ${{ matrix.compiler }}
-          CXX: ${{ matrix.compiler }}++
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         run: ./b --cfg ${{ matrix.configuration }} --arch 64 --paland -v
 
   macos:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -97,7 +97,6 @@ jobs:
       matrix:
         compiler: [gcc, clang]
         configuration: [Debug, Release]
-        architecture: [32, 64]
 
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +106,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
           CXX: ${{ matrix.compiler }}++
-        run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
+        run: ./b --cfg ${{ matrix.configuration }} --arch 64 --paland -v
 
   macos:
     runs-on: macos-latest

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -66,7 +66,7 @@ jobs:
         run: ./b --arch ${{ matrix.architecture }} --${{ matrix.sanitizer }} --paland -v
 
   linux-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ["${{ matrix.runner }}"]
 
     container:
       image: ghcr.io/charlesnicholson/docker-image:latest
@@ -78,6 +78,7 @@ jobs:
       matrix:
         configuration: [Debug, Release]
         architecture: [32, 64]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +91,7 @@ jobs:
         run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
 
   linux-clang:
-    runs-on: ubuntu-latest
+    runs-on: ["${{ matrix.runner }}"]
 
     container:
       image: ghcr.io/charlesnicholson/docker-image:latest
@@ -102,6 +103,7 @@ jobs:
       matrix:
         configuration: [Debug, Release]
         architecture: [32, 64]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -86,8 +86,8 @@ jobs:
           submodules: recursive
       - name: Build
         env:
-          CC: ${{ compiler }}
-          CXX: ${{ compiler }}++
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.compiler }}++
         run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
 
   linux-arm64:
@@ -105,8 +105,8 @@ jobs:
           submodules: recursive
       - name: Build
         env:
-          CC: ${{ compiler }}
-          CXX: ${{ compiler }}++
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.compiler }}++
         run: ./b --cfg ${{ matrix.configuration }} --arch ${{ matrix.architecture }} --paland -v
 
   macos:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -180,7 +180,7 @@ jobs:
           python3 tests/size_report.py -p host
 
   all-checks-pass:
-    needs: [pylint, download, sanitizers, linux-gcc, linux-clang, macos, win, size-reports]
+    needs: [pylint, download, sanitizers, linux-x64, linux-arm64, macos, win, size-reports]
     runs-on: ubuntu-latest
     steps:
     - run: echo Done

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -104,7 +104,6 @@ jobs:
       matrix:
         compiler: [gcc, clang]
         configuration: [Debug, Release]
-        architecture: [32, 64]
         include:
         - compiler: gcc
           cc: gcc

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -821,7 +821,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           NPF_EXTRACT(NONE, int, int);
           NPF_EXTRACT(SHORT, short, int);
           NPF_EXTRACT(LONG_DOUBLE, int, int);
-          NPF_EXTRACT(CHAR, signed char, int);
+          NPF_EXTRACT(CHAR, char, int);
           NPF_EXTRACT(LONG, long, long);
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           NPF_EXTRACT(LARGE_LONG_LONG, long long, long long);

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -821,7 +821,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           NPF_EXTRACT(NONE, int, int);
           NPF_EXTRACT(SHORT, short, int);
           NPF_EXTRACT(LONG_DOUBLE, int, int);
-          NPF_EXTRACT(CHAR, char, int);
+          NPF_EXTRACT(CHAR, signed char, int);
           NPF_EXTRACT(LONG, long, long);
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           NPF_EXTRACT(LARGE_LONG_LONG, long long, long long);


### PR DESCRIPTION
This PR re-slices the linux CI build from the top-level clang/gcc pivot to a new x64/arm64 runner pivot. arm64 uses the new stock github runners, and x64 still uses my bleeding-edge weekly docker build. 

I confirmed that this catches the bug that @kingiler reported about arm64 gcc using unsigned char by default, which they fixed in https://github.com/charlesnicholson/nanoprintf/pull/280.