### PR TITLE
option to disable the '#' flag

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Pylint build.py
         run: . /work/venv/bin/activate && python -m pylint build.py tests/size_report.py
 
-  download:
+  download-linux:
     runs-on: ubuntu-latest
 
     container:
@@ -40,6 +40,34 @@ jobs:
           submodules: recursive
       - name: Build
         run: ./b --download --paland -v
+
+  download-mac:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        run: ./b --download --paland -v
+
+  download-win:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+          python.exe build.py --download --paland -v 
+
 
   sanitizers:
     runs-on: ubuntu-latest
@@ -199,7 +227,7 @@ jobs:
           python3 tests/size_report.py -p host
 
   all-checks-pass:
-    needs: [pylint, download, sanitizers, linux-x64, linux-arm64, macos, win, size-reports]
+    needs: [pylint, download-linux, download-mac, download-win, sanitizers, linux-x64, linux-arm64, macos, win, size-reports]
     runs-on: ubuntu-latest
     steps:
     - run: echo Done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,69 +100,77 @@ foreach(fw 0 1)
       foreach(float 0 1)
         foreach(binary 0 1)
           foreach(wb 0 1)
-            if ((precision EQUAL 0) AND (float EQUAL 1))
-              continue()
-            endif()
+            foreach(alt 0 1)
+              if ((precision EQUAL 0) AND (float EQUAL 1))
+                continue()
+              endif()
 
-            set(test_name "")
-            if (fw EQUAL 1)
-              string(APPEND test_name "_fieldwidth")
-            endif()
-            if (precision EQUAL 1)
-              string(APPEND test_name "_precision")
-            endif()
-            if (large EQUAL 1)
-              string(APPEND test_name "_large")
-            endif()
-            if (float EQUAL 1)
-              string(APPEND test_name "_float")
-            endif()
-            if (binary EQUAL 1)
-              string(APPEND test_name "_binary")
-            endif()
-            if (wb EQUAL 1)
-              string(APPEND test_name "_writeback")
-            endif()
+              set(test_name "")
+              if (fw EQUAL 1)
+                string(APPEND test_name "_fieldwidth")
+              endif()
+              if (precision EQUAL 1)
+                string(APPEND test_name "_precision")
+              endif()
+              if (large EQUAL 1)
+                string(APPEND test_name "_large")
+              endif()
+              if (float EQUAL 1)
+                string(APPEND test_name "_float")
+              endif()
+              if (binary EQUAL 1)
+                string(APPEND test_name "_binary")
+              endif()
+              if (wb EQUAL 1)
+                string(APPEND test_name "_writeback")
+              endif()
+              if (alt EQUAL 1)
+                string(APPEND test_name "_altform")
+              endif()
 
-            # Run a simple compilation test
-            set(compilation_test_name "npf_compile${test_name}_c")
-            npf_compilation_c_test(${compilation_test_name})
-              target_compile_definitions(
-                ${compilation_test_name}
-                PRIVATE
-                NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=${fw}
-                NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=${precision}
-                NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=${large}
-                NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=${float}
-                NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=${binary}
-                NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=${wb})
-
-            # Run conformance tests (c++)
-            set(conformance_test_name "npf_conform${test_name}")
-            npf_test(${conformance_test_name} tests/conformance.cc)
-              target_compile_definitions(
-                ${conformance_test_name}
-                PRIVATE
-                NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=${fw}
-                NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=${precision}
-                NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=${large}
-                NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=${float}
-                NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=${binary}
-                NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=${wb})
-
-            if (NPF_PALAND)
-              set(paland_test_name "npf_paland${test_name}")
-              npf_test(${paland_test_name} tests/mpaland-conformance/paland.cc)
+              # Run a simple compilation test
+              set(compilation_test_name "npf_compile${test_name}_c")
+              npf_compilation_c_test(${compilation_test_name})
                 target_compile_definitions(
-                  ${paland_test_name}
+                  ${compilation_test_name}
                   PRIVATE
                   NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=${fw}
                   NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=${precision}
                   NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=${large}
                   NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=${float}
                   NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=${binary}
-                  NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=${wb})
-            endif()
+                  NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=${wb}
+                  NANOPRINTF_USE_ALT_FORM_FLAG=${alt})
+
+              # Run conformance tests (c++)
+              set(conformance_test_name "npf_conform${test_name}")
+              npf_test(${conformance_test_name} tests/conformance.cc)
+                target_compile_definitions(
+                  ${conformance_test_name}
+                  PRIVATE
+                  NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=${fw}
+                  NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=${precision}
+                  NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=${large}
+                  NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=${float}
+                  NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=${binary}
+                  NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=${wb}
+                  NANOPRINTF_USE_ALT_FORM_FLAG=${alt})
+
+              if (NPF_PALAND)
+                set(paland_test_name "npf_paland${test_name}")
+                npf_test(${paland_test_name} tests/mpaland-conformance/paland.cc)
+                  target_compile_definitions(
+                    ${paland_test_name}
+                    PRIVATE
+                    NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=${fw}
+                    NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=${precision}
+                    NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=${large}
+                    NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=${float}
+                    NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=${binary}
+                    NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=${wb}
+                    NANOPRINTF_USE_ALT_FORM_FLAG=${alt})
+              endif()
+            endforeach()
           endforeach()
         endforeach()
       endforeach()

--- a/build.py
+++ b/build.py
@@ -11,175 +11,197 @@ import tarfile
 import urllib.request
 import zipfile
 
-SCRIPT_PATH = pathlib.Path(__file__).resolve().parent
+_SCRIPT_PATH = pathlib.Path(__file__).resolve().parent
+_NINJA_URL = "https://github.com/ninja-build/ninja/releases/download/v1.12.1/{}"
+_CMAKE_VERSION = "4.0.1"
+_CMAKE_URL = (
+    "https://github.com/Kitware/CMake/releases/download/"
+    f"v{_CMAKE_VERSION}/cmake-{_CMAKE_VERSION}" + "-{}.{}"
+)
 
-NINJA_URL = 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/{}'
-CMAKE_URL = 'https://cmake.org/files/v3.22/{}'
 
-
-def parse_args():
+def _parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--cfg',
-        choices=[
-            'Debug',
-            'RelWithDebInfo',
-            'Release'],
-        default='Release',
-        const='Release',
-        nargs='?',
-        help='CMake configuration')
+        "--cfg",
+        choices=["Debug", "RelWithDebInfo", "Release"],
+        default="Release",
+        const="Release",
+        nargs="?",
+        help="CMake configuration",
+    )
     parser.add_argument(
-        '--arch',
+        "--arch",
         type=int,
         choices=(32, 64),
         default=64,
         const=64,
-        nargs='?',
-        help='Target architecture')
+        nargs="?",
+        help="Target architecture",
+    )
     parser.add_argument(
-        '--paland',
-        help='Compile with Paland\'s printf conformance suite',
-        action='store_true')
+        "--paland",
+        help="Compile with Paland's printf conformance suite",
+        action="store_true",
+    )
     parser.add_argument(
-        '--download',
-        help='Download CMake and Ninja, don\'t use local copies',
-        action='store_true')
-    parser.add_argument('--ubsan', action='store_true', help='Clang UB sanitizer')
-    parser.add_argument('--asan', action='store_true', help='Clang addr sanitizer')
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose')
+        "--download",
+        help="Download CMake and Ninja, don't use local copies",
+        action="store_true",
+    )
+    parser.add_argument("--ubsan", action="store_true", help="Clang UB sanitizer")
+    parser.add_argument("--asan", action="store_true", help="Clang addr sanitizer")
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose")
     return parser.parse_args()
 
 
-def download_file(url, local_path, verbose):
+def download_file(url: str, local_path: pathlib.Path, verbose: bool) -> None:
     """Download a file from url to local_path."""
     if verbose:
-        print(f'Downloading:\n  Remote: {url}\n  Local: {local_path}')
-    with urllib.request.urlopen(url) as rsp, open(local_path, 'wb') as file:
+        print(f"Downloading:\n  Remote: {url}\n  Local: {local_path}")
+    with urllib.request.urlopen(url) as rsp, open(local_path, "wb") as file:
         shutil.copyfileobj(rsp, file)
 
 
-def get_cmake(download, verbose):
+def _get_cmake(download: bool, verbose: bool) -> pathlib.Path:
     """Return the path to system CMake, or download and unpack a local copy."""
     if not download:
-        cmake = shutil.which('cmake')
+        cmake = shutil.which("cmake")
         if cmake:
-            return cmake
+            return pathlib.Path(cmake)
 
     plat = {
-        'darwin': 'macos-universal',
-        'linux': 'linux-x86_64',
-        'win32': 'win64-x86_64'}[
-        sys.platform]
-    cmake_prefix = f'cmake-3.22.2-{plat}'
-    cmake_local_dir = SCRIPT_PATH / 'external' / 'cmake'
-    cmake_file = f'{cmake_prefix}.tar.gz'
-    cmake_local_tgz = cmake_local_dir / cmake_file
-    cmake_local_exe = cmake_local_dir / cmake_prefix / \
-        ('CMake.app/Contents' if sys.platform == 'darwin' else '') / 'bin' / 'cmake'
+        "darwin": "macos-universal",
+        "linux": "linux-x86_64",
+        "win32": "windows-x86_64",
+    }[sys.platform]
+
+    suffix = "zip" if sys.platform == "win32" else "tar.gz"
+
+    cmake_prefix = f"cmake-{_CMAKE_VERSION}-{plat}"
+    cmake_local_dir = _SCRIPT_PATH / "external/cmake"
+    cmake_file = f"{cmake_prefix}.{suffix}"
+    cmake_local_archive = cmake_local_dir / cmake_file
+    cmake_local_exe = (
+        cmake_local_dir
+        / cmake_prefix
+        / ("CMake.app/Contents" if sys.platform == "darwin" else "")
+        / "bin/cmake"
+    )
 
     if not cmake_local_exe.exists():
-        if not cmake_local_tgz.exists():
+        if not cmake_local_archive.exists():
             cmake_local_dir.mkdir(parents=True, exist_ok=True)
-            download_file(
-                CMAKE_URL.format(cmake_file),
-                cmake_local_tgz,
-                verbose)
-        with tarfile.open(cmake_local_tgz, 'r') as tar:
-            for member in tar.getmembers():
-                member_path = pathlib.Path(cmake_local_dir / member.name).resolve()
-                if not cmake_local_dir in member_path.parents:
-                    raise ValueError('Tar file contents move upwards past sandbox root')
-            tar.extractall(path=cmake_local_dir)
+            download_file(_CMAKE_URL.format(plat, suffix), cmake_local_archive, verbose)
+
+        match suffix:
+            case "tar.gz":
+                with tarfile.open(cmake_local_archive, "r") as tar:
+                    for member in tar.getmembers():
+                        member_path = pathlib.Path(
+                            cmake_local_dir / member.name
+                        ).resolve()
+                        if cmake_local_dir not in member_path.parents:
+                            raise ValueError(
+                                "Tar file contents move upwards past sandbox root"
+                            )
+
+                    tar.extractall(path=cmake_local_dir)
+
+            case "zip":
+                with zipfile.ZipFile(cmake_local_archive, "r") as zip_file:
+                    zip_file.extractall(cmake_local_dir)
 
     return cmake_local_exe
 
 
-def get_ninja(download, verbose):
+def _get_ninja(download: bool, verbose: bool) -> pathlib.Path:
     """Return the path to system Ninja, or download and unpack a local copy."""
     if not download:
-        ninja = shutil.which('ninja')
+        ninja = shutil.which("ninja")
         if ninja:
-            return ninja
+            return pathlib.Path(ninja)
 
-    ninja_local_dir = SCRIPT_PATH / 'external' / 'ninja'
-    plat = {'darwin': 'mac', 'linux': 'linux', 'win32': 'win'}[sys.platform]
-    ninja_file = f'ninja-{plat}.zip'
+    ninja_local_dir = _SCRIPT_PATH / "external/ninja"
+    plat = {"darwin": "mac", "linux": "linux", "win32": "win"}[sys.platform]
+    ninja_file = f"ninja-{plat}.zip"
     ninja_local_zip = ninja_local_dir / ninja_file
-    ninja_local_exe = ninja_local_dir / f'ninja{".exe" if plat == "win" else ""}'
+    ninja_local_exe = ninja_local_dir / f"ninja{'.exe' if plat == 'win' else ''}"
 
     if not ninja_local_exe.exists():
         if not ninja_local_zip.exists():
             ninja_local_dir.mkdir(parents=True, exist_ok=True)
-            download_file(
-                NINJA_URL.format(ninja_file),
-                ninja_local_zip,
-                verbose)
-        with zipfile.ZipFile(ninja_local_zip, 'r') as zip_file:
+            download_file(_NINJA_URL.format(ninja_file), ninja_local_zip, verbose)
+
+        with zipfile.ZipFile(ninja_local_zip, "r") as zip_file:
             zip_file.extractall(ninja_local_dir)
-        os.chmod(ninja_local_exe, os.stat(
-            ninja_local_exe).st_mode | stat.S_IEXEC)
+
+        os.chmod(ninja_local_exe, os.stat(ninja_local_exe).st_mode | stat.S_IEXEC)
 
     return ninja_local_exe
 
 
-def configure_cmake(cmake_exe, ninja, args):
+def _configure_cmake(
+    cmake_exe: pathlib.Path, ninja: pathlib.Path, args: argparse.Namespace
+) -> bool:
     """Prepare CMake for building nanoprintf tests under 'build/ninja/<cfg>'."""
-    build_path = SCRIPT_PATH / 'build' / 'ninja' / args.cfg
-    if (build_path / 'CMakeFiles').exists():
+    build_path = _SCRIPT_PATH / "build/ninja" / args.cfg
+    if (build_path / "CMakeFiles").exists():
         return True
 
     sys.stdout.flush()
     build_path.mkdir(parents=True)
 
-    cmake_args = [cmake_exe,
-                  SCRIPT_PATH,
-                  '-G',
-                  'Ninja',
-                  '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-                  f'-DCMAKE_MAKE_PROGRAM={ninja}',
-                  f'-DCMAKE_BUILD_TYPE={args.cfg}',
-                  f'-DNPF_PALAND={"ON" if args.paland else "OFF"}',
-                  f'-DNPF_32BIT={"ON" if args.arch == 32 else "OFF"}',
-                  f'-DNPF_CLANG_ASAN={"ON" if args.asan else "OFF"}',
-                  f'-DNPF_CLANG_UBSAN={"ON" if args.ubsan else "OFF"}']
+    cmake_args = [
+        cmake_exe,
+        _SCRIPT_PATH,
+        "-G",
+        "Ninja",
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        f"-DCMAKE_MAKE_PROGRAM={ninja}",
+        f"-DCMAKE_BUILD_TYPE={args.cfg}",
+        f"-DNPF_PALAND={'ON' if args.paland else 'OFF'}",
+        f"-DNPF_32BIT={'ON' if args.arch == 32 else 'OFF'}",
+        f"-DNPF_CLANG_ASAN={'ON' if args.asan else 'OFF'}",
+        f"-DNPF_CLANG_UBSAN={'ON' if args.ubsan else 'OFF'}",
+    ]
+
     try:
-        return subprocess.run(
-            cmake_args,
-            cwd=build_path,
-            check=True).returncode == 0
+        return subprocess.run(cmake_args, cwd=build_path, check=True).returncode == 0
     except subprocess.CalledProcessError as cpe:
         return cpe.returncode == 0
 
 
-def build_cmake(cmake_exe, args):
+def _build_cmake(cmake_exe: pathlib.Path, args: argparse.Namespace) -> bool:
     """Run CMake in build mode to compile and run the nanoprintf test suite."""
     sys.stdout.flush()
-    build_path = SCRIPT_PATH / 'build' / 'ninja' / args.cfg
-    cmake_args = [cmake_exe, '--build', build_path] + \
-        (['--', '-v'] if args.verbose else [])
+    build_path = _SCRIPT_PATH / "build/ninja" / args.cfg
+    cmake_args = [cmake_exe, "--build", build_path] + (
+        ["--", "-v"] if args.verbose else []
+    )
+
     try:
         return subprocess.run(cmake_args, check=True).returncode == 0
     except subprocess.CalledProcessError as cpe:
         return cpe.returncode == 0
 
 
-def main():
+def main() -> int:
     """Parse args, find or get tools, configure CMake, build and run tests."""
-    args = parse_args()
+    args = _parse_args()
 
-    cmake = get_cmake(args.download, args.verbose)
+    cmake = _get_cmake(args.download, args.verbose)
     if args.verbose:
-        print(f'Found CMake at {cmake}')
+        print(f"Found CMake at {cmake}")
 
-    ninja = get_ninja(args.download, args.verbose)
+    ninja = _get_ninja(args.download, args.verbose)
     if args.verbose:
-        print(f'Found ninja at {ninja}')
+        print(f"Found ninja at {ninja}")
 
-    built_ok = configure_cmake(cmake, ninja, args) and build_cmake(cmake, args)
+    built_ok = _configure_cmake(cmake, ninja, args) and _build_cmake(cmake, args)
     return int(not built_ok)  # 0 is success
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -80,14 +80,14 @@ NPF_VISIBILITY int npf_vpprintf(
     !defined(NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS) && \
     !defined(NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS) && \
     !defined(NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS) && \
-    !defined(NANOPRINTF_USE_ALT_FORM_MODIFIER)
+    !defined(NANOPRINTF_USE_ALT_FORM_FLAG)
   #define NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS 1
   #define NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS 1
   #define NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS 1
   #define NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS 0
   #define NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS 0
   #define NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS 0
-  #define NANOPRINTF_USE_ALT_FORM_MODIFIER 1
+  #define NANOPRINTF_USE_ALT_FORM_FLAG 1
 #endif
 
 // If anything's been configured, everything must be configured.
@@ -254,7 +254,7 @@ typedef struct npf_format_spec {
   uint8_t prec_opt;
 #endif
   char prepend;          // ' ' or '+'
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
   char alt_form;         // '#'
 #endif
   char case_adjust;      // 'a' - 'A'
@@ -301,7 +301,7 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
 #endif
   out_spec->case_adjust = 'a' - 'A'; // lowercase
   out_spec->prepend = 0;
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
   out_spec->alt_form = 0;
 #endif
 
@@ -313,7 +313,7 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
 #endif
       case '+': out_spec->prepend = '+'; continue;
       case ' ': if (out_spec->prepend == 0) { out_spec->prepend = ' '; } continue;
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
       case '#': out_spec->alt_form = '#'; continue;
 #endif
       default: break;
@@ -567,7 +567,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f) {
   uint_fast8_t carry; carry = 0;
   npf_ftoa_dec_t end, dec; dec = (npf_ftoa_dec_t)spec->prec;
   if (dec
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     || spec->alt_form
 #endif
     ) {
@@ -893,7 +893,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #endif
         if (!val && (fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec) {
           // Zero value and explicitly-requested zero precision means "print nothing".
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
           if ((fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) && fs.alt_form) {
             fs.prec = 1; // octal special case, print a single '0'
           }
@@ -911,13 +911,13 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           cbuf_len = npf_utoa_rev(val, cbuf, base, fs.case_adjust);
         }
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
         if (val && fs.alt_form && (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL)) {
           cbuf[cbuf_len++] = '0'; // OK to add leading octal '0' immediately.
         }
 #endif
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
         if (val && fs.alt_form) { // 0x or 0b but can't write it yet.
           if (fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) { need_0x = 'X'; }
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -301,7 +301,7 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
 #endif
   out_spec->case_adjust = 'a' - 'A'; // lowercase
   out_spec->prepend = 0;
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
   out_spec->alt_form = 0;
 #endif
 
@@ -313,7 +313,7 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
 #endif
       case '+': out_spec->prepend = '+'; continue;
       case ' ': if (out_spec->prepend == 0) { out_spec->prepend = ' '; } continue;
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
       case '#': out_spec->alt_form = '#'; continue;
 #endif
       default: break;
@@ -567,7 +567,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f) {
   uint_fast8_t carry; carry = 0;
   npf_ftoa_dec_t end, dec; dec = (npf_ftoa_dec_t)spec->prec;
   if (dec
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
     || spec->alt_form
 #endif
     ) {
@@ -893,7 +893,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #endif
         if (!val && (fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec) {
           // Zero value and explicitly-requested zero precision means "print nothing".
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
           if ((fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) && fs.alt_form) {
             fs.prec = 1; // octal special case, print a single '0'
           }
@@ -911,13 +911,13 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           cbuf_len = npf_utoa_rev(val, cbuf, base, fs.case_adjust);
         }
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
         if (val && fs.alt_form && (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL)) {
           cbuf[cbuf_len++] = '0'; // OK to add leading octal '0' immediately.
         }
 #endif
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER == 1
         if (val && fs.alt_form) { // 0x or 0b but can't write it yet.
           if (fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) { need_0x = 'X'; }
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1

--- a/tests/conformance.cc
+++ b/tests/conformance.cc
@@ -69,7 +69,9 @@ TEST_CASE("conformance to system printf") {
 #endif // NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS
     require_conform("%", "% %");
     require_conform("%", "%+%");
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("%", "%#%");
+#endif
     // require_conform("         %", "%10%"); clang adds width, gcc doesn't
     // require_conform("%         ", "%-10%"); clang adds -width, gcc doesn't
     // require_conform("         %", "%10.10%"); clang adds width + precision.
@@ -240,7 +242,9 @@ TEST_CASE("conformance to system printf") {
 
   SUBCASE("octal") {
     require_conform("0", "%o", 0);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("0", "%#o", 0);
+#endif
     require_conform("37777777777", "%o", UINT_MAX);
     require_conform("17", "%ho", (1 << 29u) + 15u);
 #if ULONG_MAX > UINT_MAX
@@ -250,7 +254,9 @@ TEST_CASE("conformance to system printf") {
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     require_conform("      2322", "%10o", 1234);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("     02322", "%#10o", 1234);
+#endif
     require_conform("0001", "%04o", 1);
     require_conform("0000", "%04o", 0);
     require_conform("0", "%+o", 0);
@@ -261,7 +267,9 @@ TEST_CASE("conformance to system printf") {
 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
     require_conform("", "%.0o", 0);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("0", "%#.0o", 0);
+#endif
 #endif // NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS
 
 #if (NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1)
@@ -294,7 +302,9 @@ TEST_CASE("conformance to system printf") {
     require_conform("0", "%X", 0);
     require_conform("90ABCDEF", "%X", 0x90ABCDEF);
     require_conform("FFFFFFFF", "%X", UINT_MAX);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("0", "%#x", 0);
+#endif
     require_conform("0", "%+x", 0);
     require_conform("1", "%+x", 1);
     require_conform("7b", "%hx", (1 << 26u) + 123u);
@@ -305,7 +315,9 @@ TEST_CASE("conformance to system printf") {
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     require_conform("      1234", "%10x", 0x1234);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("    0x1234", "%#10x", 0x1234);
+#endif
     require_conform("0001", "%04u", 1);
     require_conform("0000", "%04u", 0);
     require_conform("     0", "% 6x", 0);
@@ -315,7 +327,9 @@ TEST_CASE("conformance to system printf") {
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
     require_conform("", "%.0x", 0);
     require_conform("", "%.0X", 0);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("", "%#.0X", 0);
+#endif
 #endif // NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS
 
 #if (NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1)
@@ -480,7 +494,9 @@ TEST_CASE("conformance to system printf") {
     require_conform("0.00", "%.2f", 0.0);
     require_conform("1.0", "%.1f", 1.0);
     require_conform("1", "%.0f", 1.0);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     require_conform("1.", "%#.0f", 1.0);
+#endif
     require_conform("1.00000000000", "%.11f", 1.0);
     require_conform("1.5", "%.1f", 1.5);
     require_conform("+1.5", "%+.1f", 1.5);

--- a/tests/conformance.cc
+++ b/tests/conformance.cc
@@ -69,7 +69,7 @@ TEST_CASE("conformance to system printf") {
 #endif // NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS
     require_conform("%", "% %");
     require_conform("%", "%+%");
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("%", "%#%");
 #endif
     // require_conform("         %", "%10%"); clang adds width, gcc doesn't
@@ -242,7 +242,7 @@ TEST_CASE("conformance to system printf") {
 
   SUBCASE("octal") {
     require_conform("0", "%o", 0);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("0", "%#o", 0);
 #endif
     require_conform("37777777777", "%o", UINT_MAX);
@@ -254,7 +254,7 @@ TEST_CASE("conformance to system printf") {
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     require_conform("      2322", "%10o", 1234);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("     02322", "%#10o", 1234);
 #endif
     require_conform("0001", "%04o", 1);
@@ -267,7 +267,7 @@ TEST_CASE("conformance to system printf") {
 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
     require_conform("", "%.0o", 0);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("0", "%#.0o", 0);
 #endif
 #endif // NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS
@@ -302,7 +302,7 @@ TEST_CASE("conformance to system printf") {
     require_conform("0", "%X", 0);
     require_conform("90ABCDEF", "%X", 0x90ABCDEF);
     require_conform("FFFFFFFF", "%X", UINT_MAX);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("0", "%#x", 0);
 #endif
     require_conform("0", "%+x", 0);
@@ -315,7 +315,7 @@ TEST_CASE("conformance to system printf") {
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     require_conform("      1234", "%10x", 0x1234);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("    0x1234", "%#10x", 0x1234);
 #endif
     require_conform("0001", "%04u", 1);
@@ -327,7 +327,7 @@ TEST_CASE("conformance to system printf") {
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
     require_conform("", "%.0x", 0);
     require_conform("", "%.0X", 0);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("", "%#.0X", 0);
 #endif
 #endif // NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS
@@ -494,7 +494,7 @@ TEST_CASE("conformance to system printf") {
     require_conform("0.00", "%.2f", 0.0);
     require_conform("1.0", "%.1f", 1.0);
     require_conform("1", "%.0f", 1.0);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     require_conform("1.", "%#.0f", 1.0);
 #endif
     require_conform("1.00000000000", "%.11f", 1.0);

--- a/tests/unit_binary.cc
+++ b/tests/unit_binary.cc
@@ -133,7 +133,7 @@ TEST_CASE("binary") {
   }
 #endif
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
   SUBCASE("alternate form") {
     require_equal("0", "%#b", 0);
     require_equal("0b1", "%#b", 1);

--- a/tests/unit_binary.cc
+++ b/tests/unit_binary.cc
@@ -133,6 +133,7 @@ TEST_CASE("binary") {
   }
 #endif
 
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
   SUBCASE("alternate form") {
     require_equal("0", "%#b", 0);
     require_equal("0b1", "%#b", 1);
@@ -146,4 +147,5 @@ TEST_CASE("binary") {
 #endif
 #endif
   }
+#endif
 }

--- a/tests/unit_ftoa_rev.cc
+++ b/tests/unit_ftoa_rev.cc
@@ -61,8 +61,10 @@ TEST_CASE("ftoa_rev") {
   SUBCASE("zero and decimal separator") {
     require_ftoa_rev("0", +0.);
     require_ftoa_rev("0", -0.);
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     spec.alt_form = '#';
     require_ftoa_rev("0.", 0.);
+#endif
     spec.prec = 1;
     require_ftoa_rev("0.0", 0.);
   }

--- a/tests/unit_ftoa_rev.cc
+++ b/tests/unit_ftoa_rev.cc
@@ -61,7 +61,7 @@ TEST_CASE("ftoa_rev") {
   SUBCASE("zero and decimal separator") {
     require_ftoa_rev("0", +0.);
     require_ftoa_rev("0", -0.);
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     spec.alt_form = '#';
     require_ftoa_rev("0.", 0.);
 #endif

--- a/tests/unit_parse_format_spec.cc
+++ b/tests/unit_parse_format_spec.cc
@@ -104,7 +104,7 @@ TEST_CASE("npf_parse_format_spec") {
        conversions, the behavior is undefined.
     */
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
     REQUIRE(!npf_parse_format_spec("%#", &spec)); // alternative form alone
 
     SUBCASE("alternative form off by default") {

--- a/tests/unit_parse_format_spec.cc
+++ b/tests/unit_parse_format_spec.cc
@@ -104,6 +104,7 @@ TEST_CASE("npf_parse_format_spec") {
        conversions, the behavior is undefined.
     */
 
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
     REQUIRE(!npf_parse_format_spec("%#", &spec)); // alternative form alone
 
     SUBCASE("alternative form off by default") {
@@ -120,6 +121,7 @@ TEST_CASE("npf_parse_format_spec") {
       REQUIRE(npf_parse_format_spec("%#####u", &spec) == 7);
       REQUIRE(spec.alt_form);
     }
+#endif
 
     /*
         '0': For d, i, o, u, x, X, a, A, e, E, f, F, g, and G conversions, leading

--- a/tests/unit_vpprintf.cc
+++ b/tests/unit_vpprintf.cc
@@ -261,6 +261,7 @@ TEST_CASE("npf_vpprintf") {
     REQUIRE(r.String() == std::string{"ABCD"});
   }
 
+#if NANOPRINTF_USE_ALT_FORM_MODIFIER
   SUBCASE("alternative flag: hex doesn't prepend 0x if value is 0") {
     REQUIRE(npf_pprintf(r.PutC, &r, "%#x", 0) == 1);
     REQUIRE(r.String() == std::string{"0"});
@@ -285,4 +286,5 @@ TEST_CASE("npf_vpprintf") {
     REQUIRE(npf_pprintf(r.PutC, &r, "%#o", 2) == 2);
     REQUIRE(r.String() == std::string{"02"});
   }
+#endif
 }

--- a/tests/unit_vpprintf.cc
+++ b/tests/unit_vpprintf.cc
@@ -261,7 +261,7 @@ TEST_CASE("npf_vpprintf") {
     REQUIRE(r.String() == std::string{"ABCD"});
   }
 
-#if NANOPRINTF_USE_ALT_FORM_MODIFIER
+#if NANOPRINTF_USE_ALT_FORM_FLAG == 1
   SUBCASE("alternative flag: hex doesn't prepend 0x if value is 0") {
     REQUIRE(npf_pprintf(r.PutC, &r, "%#x", 0) == 1);
     REQUIRE(r.String() == std::string{"0"});


### PR DESCRIPTION
'#' has limited use ("0x/0b" prefix, single "0" for octal, "." always present for floats).
Removing it --ie still parsing it, but ignoring it-- will save some code for a feature that might not be needed at all in some code bases.

If '#' is disabled, the 'alt_form' field in npf_format_spec_t is conditionally-removed.
Because of this possibility, it is be beneficial to reorder the fields of npf_format_spec_t
For instance, on systems with 2-byte integers, this reordering can reduce the struct size from 13+1 bytes to 12 bytes, if the library is configured as:
NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS    1
NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS      1
NANOPRINTF_USE_ALT_FORM_MODIFIER                0