### PR TITLE
fixed: the '0' flag must be ignored in case of nan/inf (or error)

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -677,7 +677,7 @@ exit:
   if (!ret) { ret = "RRE"; }
   uint_fast8_t i;
   for (i = 0; ret[i]; ++i) { buf[i] = (char)(ret[i] + spec->case_adjust); }
-  return (int)i;
+  return -(int)i;
 }
 
 #endif // NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS
@@ -949,6 +949,10 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
         zero = (val == 0.);
 #endif
         cbuf_len = npf_ftoa_rev(cbuf, &fs, val);
+        if (cbuf_len < 0) { // negative means "err" or non-finite, for which we must ignore the '0' flag
+           cbuf_len = -cbuf_len;
+           fs.leading_zero_pad = 0;
+        }
       } break;
 #endif
       default: break;

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -951,7 +951,9 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
         cbuf_len = npf_ftoa_rev(cbuf, &fs, val);
         if (cbuf_len < 0) { // negative means "err" or non-finite, for which we must ignore the '0' flag
            cbuf_len = -cbuf_len;
+#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
            fs.leading_zero_pad = 0;
+#endif
         }
       } break;
 #endif


### PR DESCRIPTION
See the C23 standard
(here the latest open draft: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf)
Around §7.23.6.1, it says, in a footnote:

`When applied to infinite and NaN values, the -, +, and space flag characters have their usual meaning; the # and 0 flag characters have no effect`


This is what happens with NPF:
```
printf("%08f", 0/0.0); // "00000nan"
printf("%08f", -1/0.0); // "-0000inf"
```

This is what happens with standard-conforming implementations:
```
printf("%08f", 0/0.0); // "     nan"
printf("%08f", -1/0.0); // "    -inf"
```

To resolve the problem, I did this: npf_ftoa_rev() returns a negative value for non-finite results (nan/inf/err). The caller, on seeing the negative result, clears the 'leading_zero_pad' field, and takes the absolute value of the result. There's no need to touch the 'alt_form' field, since its code path is already skipped inside the npf_ftoa_rev() function.

I haven't added these cases to the tests, but you might want to.
I would also add some other nan tests, not relying on the predefined NAN or on calculations like (0.0/0) or (INFINITY/INFINITY) or (INFINITY - INFINITY), since we don't know which kind of nan the produce (eg GCC seems to prefer a negative nan, while clang/MSVC seem to prefer a positive nan).

These are most test cases, and below are some nan-generating functions which let you pick the exact nan you want.

```
// lowercase
require_conform("nan" , "%f", npf_nan(0, 1, 0));
require_conform("-nan", "%f", npf_nan(1, 1, 0));
require_conform("nan" , "%f", npf_nan(0, 1, 1));
require_conform("-nan", "%f", npf_nan(1, 1, 1));
require_conform("nan" , "%f", npf_nan(0, 0, 0));
require_conform("-nan", "%f", npf_nan(1, 0, 0));
require_conform("nan" , "%f", npf_nan(0, 0, 1));
require_conform("-nan", "%f", npf_nan(1, 0, 1));

// uppercase
require_conform("NAN" , "%F", npf_nan(0, 1, 0));
require_conform("-NAN", "%F", npf_nan(1, 1, 0));
require_conform("NAN" , "%F", npf_nan(0, 1, 1));
require_conform("-NAN", "%F", npf_nan(1, 1, 1));
require_conform("NAN" , "%F", npf_nan(0, 0, 0));
require_conform("-NAN", "%F", npf_nan(1, 0, 0));
require_conform("NAN" , "%F", npf_nan(0, 0, 1));
require_conform("-NAN", "%F", npf_nan(1, 0, 1));

// Standard:
// ===
// When applied to infinite and NaN values, the -, +, and space flag characters have their usual
// meaning; the # and 0 flag characters have no effect
// ===
// Nothing is said about the width (we assume it is respected), nor the precision (we just ignore
// it, since we have no decimal places)
require_conform("   nan", "%06f", npf_nan(0, 1, 0));
require_conform("  -nan", "%06f", npf_nan(1, 1, 0));
require_conform("  +nan", "%+6f", npf_nan(0, 1, 0));
require_conform("  -nan", "%+6f", npf_nan(1, 1, 0));
require_conform("   nan", "%#6f", npf_nan(0, 1, 0));
require_conform("  -nan", "%#6f", npf_nan(1, 1, 0));
require_conform("   nan", "%#06f", npf_nan(0, 1, 0));
require_conform("  -nan", "%#06f", npf_nan(1, 1, 0));
require_conform("   nan", "% 6f", npf_nan(0, 1, 0));
require_conform("  -nan", "% 6f", npf_nan(1, 1, 0));
require_conform(" nan", "% 1f", npf_nan(0, 1, 0));
require_conform("-nan", "% 1f", npf_nan(1, 1, 0));
require_conform("nan   ", "%-6f", npf_nan(0, 1, 0));
require_conform("-nan  ", "%-6f", npf_nan(1, 1, 0));

require_conform("nan", "%0.6f", npf_nan(0, 1, 0));
require_conform("-nan", "%0.6f", npf_nan(1, 1, 0));
require_conform("+nan", "%+.6f", npf_nan(0, 1, 0));
require_conform("-nan", "%+.6f", npf_nan(1, 1, 0));
require_conform("nan", "%#.6f", npf_nan(0, 1, 0));
require_conform("-nan", "%#.6f", npf_nan(1, 1, 0));
require_conform("nan", "%#0.6f", npf_nan(0, 1, 0));
require_conform("-nan", "%#0.6f", npf_nan(1, 1, 0));
require_conform(" nan", "% .1f", npf_nan(0, 1, 0));
require_conform("-nan", "% .1f", npf_nan(1, 1, 0));
require_conform("nan", "%-.6f", npf_nan(0, 1, 0));
require_conform("-nan", "%-.6f", npf_nan(1, 1, 0));

require_conform("   inf", "%06f", INFINITY);
require_conform("  -inf", "%06f", -INFINITY);
require_conform("  +inf", "%+6f", INFINITY);
require_conform("  -inf", "%+6f", -INFINITY);
require_conform("   inf", "%#6f", INFINITY);
require_conform("  -inf", "%#6f", -INFINITY);
require_conform("   inf", "%#06f", INFINITY);
require_conform("  -inf", "%#06f", -INFINITY);
require_conform("   inf", "% 6f", INFINITY);
require_conform("  -inf", "% 6f", -INFINITY);
require_conform(" inf", "% 1f", INFINITY);
require_conform("-inf", "% 1f", -INFINITY);
require_conform("inf   ", "%-6f", INFINITY);
require_conform("-inf  ", "%-6f", -INFINITY);

require_conform("inf", "%0.6f", INFINITY);
require_conform("-inf", "%0.6f", -INFINITY);
require_conform("+inf", "%+.6f", INFINITY);
require_conform("-inf", "%+.6f", -INFINITY);
require_conform("inf", "%#.6f", INFINITY);
require_conform("-inf", "%#.6f", -INFINITY);
require_conform("inf", "%#0.6f", INFINITY);
require_conform("-inf", "%#0.6f", -INFINITY);
require_conform(" inf", "% .1f", INFINITY);
require_conform("-inf", "% .1f", -INFINITY);
require_conform("inf", "%-.6f", INFINITY);
require_conform("-inf", "%-.6f", -INFINITY);

double npf_u64_to_dbl(uint64_t v)
{
    double d;
    memcpy(&d, &v, 8);
    return d;
}

double npf_nan(bool negative, bool quiet, uint64_t extra_payload)
{
    // compile-time check that double fits in uint64_t
#if FLT_RADIX != 2 || DBL_MAX_EXP > 1024 || DBL_MANT_DIG > 53 || CHAR_BIT != 8
    #error Unsupported double format
#endif
    //_Static_assert(sizeof(double) <= sizeof(uint64_t));

    // IEEE 754 floating-point values are encoded as <sign><exp><mantissa>
    // NAN has <exp> set to the maximum value (all 1s), and non-0 <mantissa> (to distinguish it from infinities)
    // A NAN value can encode arbitrary data in the mantissa (as long as it is non-0).
    // "signalling NANs" have the highest mantissa bit set to 0.
    // "quiet NANs" have the highest mantissa bit set to 1.

    const int DBL_MANT_BITS = DBL_MANT_DIG - 1; // 1 digit is implicit
    const int DBL_EXP_BITS = sizeof(double) * CHAR_BIT - 1 - DBL_MANT_BITS;
    const int DBL_SIGN_POS = DBL_EXP_BITS + DBL_MANT_BITS;
    extra_payload &= (1ull << DBL_MANT_BITS) - 1;
    if (quiet) {
        extra_payload |= 1ull << (DBL_MANT_BITS - 1);
    }
    if (extra_payload == 0) {
        extra_payload = 1;
    }
    uint64_t u = 0ull
        | ((negative ? 1ull : 0ull) << DBL_SIGN_POS) // sign
        | (((1ull << DBL_EXP_BITS) - 1) << DBL_MANT_BITS) // make nan/inf exponent
        | extra_payload
        ;

    return npf_u64_to_dbl(u);
}
```