### PR TITLE
Fixed wrong sign for negative zero

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -515,7 +515,7 @@ enum {
   NPF_DOUBLE_EXP_BIAS = DBL_MAX_EXP - 1,
   NPF_DOUBLE_MAN_BITS = DBL_MANT_DIG - 1,
   NPF_DOUBLE_BIN_BITS = sizeof(npf_double_bin_t) * CHAR_BIT,
-  NPF_DOUBLE_SIGN_POS = sizeof(double) * CHAR_BIT - 1, // this is true for f32 and f64; if we were paranoid, we should calculate it as (NPF_DOUBLE_MAN_BITS + NPF_DOUBLE_EXP_BITS), where NPF_DOUBLE_EXP_BITS is ceil(log2(DBL_MAX_EXP)), hard to get as a compile-time constant unless we check against all the possible powers-of-2
+  NPF_DOUBLE_SIGN_POS = sizeof(double) * CHAR_BIT - 1, // this is true for f32 and f64; if we were paranoid, we should calculate it as (NPF_DOUBLE_MAN_BITS + NPF_DOUBLE_EXP_BITS), where NPF_DOUBLE_EXP_BITS is ceil(log2(DBL_MAX_EXP-DBL_MIN_EXP)), hard to get as a compile-time constant unless we check against all the possible powers-of-2
   NPF_FTOA_MAN_BITS   = sizeof(npf_ftoa_man_t) * CHAR_BIT,
   NPF_FTOA_SHIFT_BITS =
     ((NPF_FTOA_MAN_BITS < DBL_MANT_DIG) ? NPF_FTOA_MAN_BITS : DBL_MANT_DIG) - 1

--- a/tests/conformance.cc
+++ b/tests/conformance.cc
@@ -467,6 +467,7 @@ TEST_CASE("conformance to system printf") {
 
   SUBCASE("float") {
     require_conform("inf", "%f", (double)INFINITY);
+    require_conform("-inf", "%f", -(double)INFINITY);
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     require_conform(" inf", "%4f", (double)INFINITY);
 #endif // NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS
@@ -477,6 +478,9 @@ TEST_CASE("conformance to system printf") {
     require_conform("inf", "%.10a", (double)INFINITY);
     require_conform("INF", "%F", (double)INFINITY);
     require_conform("0.000000", "%f", 0.0);
+    require_conform("-0.000000", "%f", -0.0);
+    require_conform("0.000000", "%f", 1e-20);
+    require_conform("-0.000000", "%f", -1e-20);
     require_conform("0.00", "%.2f", 0.0);
     require_conform("1.0", "%.1f", 1.0);
     require_conform("1", "%.0f", 1.0);


### PR DESCRIPTION
The standard says, in a footnote:
```
The results of all floating conversions of a negative zero, and of negative values that round to zero, include a minus sign.
```