### PR TITLE
Less surprising UB for width/precision associated to %c %s %%

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -380,19 +380,18 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
     case '%': out_spec->conv_spec = NPF_FMT_SPEC_CONV_PERCENT;
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
       out_spec->prec_opt = NPF_FMT_SPEC_OPT_NONE;
+      out_spec->prec = 0;
 #endif
       break;
 
     case 'c': out_spec->conv_spec = NPF_FMT_SPEC_CONV_CHAR;
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
       out_spec->prec_opt = NPF_FMT_SPEC_OPT_NONE;
+      out_spec->prec = 0;
 #endif
       break;
 
     case 's': out_spec->conv_spec = NPF_FMT_SPEC_CONV_STRING;
-#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-      out_spec->leading_zero_pad = 0;
-#endif
       break;
 
     case 'i':
@@ -957,17 +956,13 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     // Compute the field width pad character
     if (fs.field_width_opt != NPF_FMT_SPEC_OPT_NONE) {
-      if (fs.leading_zero_pad) { // '0' flag is only legal with numeric types
-        if ((fs.conv_spec != NPF_FMT_SPEC_CONV_STRING) &&
-            (fs.conv_spec != NPF_FMT_SPEC_CONV_CHAR) &&
-            (fs.conv_spec != NPF_FMT_SPEC_CONV_PERCENT)) {
+      if (fs.leading_zero_pad) {
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-          if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero) {
-            pad_c = ' ';
-          } else
+        if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero) {
+          pad_c = ' ';
+        } else
 #endif
-          { pad_c = '0'; }
-        }
+        { pad_c = '0'; }
       } else { pad_c = ' '; }
     }
 #endif


### PR DESCRIPTION
Before this fix, we have (NPF vs other implementations):
```
printf("%10c", 'a');    // "         a" vs "         a"
printf("%010c", 'a');   // "a"          vs "000000000a"
printf("%10s" , "abc"); // "       abc" vs "       abc"
printf("%010s", "abc"); // "       abc" vs "0000000abc"
printf("%010%");        // "%"          vs "%"
printf("%10%");         // "         %" vs "%"
printf("%.2c" , 'a');   // "0a" vs "a"
printf("%.2s" , "abc"); // "ab" vs "ab"
printf("%.2%");         // "0%" vs "%"
```
Afterwards:
```
printf("%10c", 'a');    // "         a"
printf("%010c", 'a');   // "000000000a"
printf("%10s" , "abc"); // "       abc"
printf("%010s", "abc"); // "0000000abc"
printf("%010%");        // "000000000%"
printf("%10%");         // "         %"
printf("%.2c" , 'a');   // "a"
printf("%.2s" , "abc"); // "ab"
printf("%.2%");         // "%"
```

The standard describes the width field in general, for any conversion specifier.
It makes no special provisions for 'c'. Compare with 'n', for which it is explicitly stated:
```
If the conversion specification includes any flags, a field width, or a precision, the behavior is undefined.
```
and also for '%':
```
The complete conversion specification shall be %%
```
So, I would say that 'c' should respect the field width just like 's'.

The problem for NPF originates from the '0' flag, which is illegal for 'c', so we have UB, and NPF is technically conforming. See the dedicated code around line 960.
However, padding with '0' is less surprising than just ignoring the width altogether. It's also more consistent across 'c' and 's' and '%'.
This also removes some checks, resulting in a smaller code footprint, while remaining standard-conforming.

Notice that ignoring '0' was done around line 393 for 's', which caused the different treatment of 'c' and 's' around line 960.

Similarly, I've removed some checks for '%', which make it more consistent (still UB, hence conforming) and smaller.
Finally, I've and added a couple prec=0 assignments to avoid spurious '0' padding when we ignore the precision, though this means more code.