### PR TITLE
Removed default '#' from %p

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -855,22 +855,27 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #endif
       case NPF_FMT_SPEC_CONV_OCTAL:
       case NPF_FMT_SPEC_CONV_HEX_INT:
-      case NPF_FMT_SPEC_CONV_UNSIGNED_INT: {
+      case NPF_FMT_SPEC_CONV_UNSIGNED_INT:
+      case NPF_FMT_SPEC_CONV_POINTER: {
         npf_uint_t val = 0;
 
-        switch (fs.length_modifier) {
-          NPF_EXTRACT(NONE, unsigned, unsigned);
-          NPF_EXTRACT(SHORT, unsigned short, unsigned);
-          NPF_EXTRACT(LONG_DOUBLE, unsigned, unsigned);
-          NPF_EXTRACT(CHAR, unsigned char, unsigned);
-          NPF_EXTRACT(LONG, unsigned long, unsigned long);
+        if (fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER) {
+          val = (npf_uint_t)(uintptr_t)va_arg(args, void *);
+        } else {
+          switch (fs.length_modifier) {
+            NPF_EXTRACT(NONE, unsigned, unsigned);
+            NPF_EXTRACT(SHORT, unsigned short, unsigned);
+            NPF_EXTRACT(LONG_DOUBLE, unsigned, unsigned);
+            NPF_EXTRACT(CHAR, unsigned char, unsigned);
+            NPF_EXTRACT(LONG, unsigned long, unsigned long);
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-          NPF_EXTRACT(LARGE_LONG_LONG, unsigned long long, unsigned long long);
-          NPF_EXTRACT(LARGE_INTMAX, uintmax_t, uintmax_t);
-          NPF_EXTRACT(LARGE_SIZET, size_t, size_t);
-          NPF_EXTRACT(LARGE_PTRDIFFT, size_t, size_t);
+            NPF_EXTRACT(LARGE_LONG_LONG, unsigned long long, unsigned long long);
+            NPF_EXTRACT(LARGE_INTMAX, uintmax_t, uintmax_t);
+            NPF_EXTRACT(LARGE_SIZET, size_t, size_t);
+            NPF_EXTRACT(LARGE_PTRDIFFT, size_t, size_t);
 #endif
-          default: break;
+            default: break;
+          }
         }
 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
@@ -891,7 +896,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #endif
         {
           uint_fast8_t const base = (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) ?
-            8u : ((fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) ? 16u : 10u);
+            8u : ((fs.conv_spec == NPF_FMT_SPEC_CONV_UNSIGNED_INT) ? 10u : 16u);
           cbuf_len = npf_utoa_rev(val, cbuf, base, fs.case_adjust);
         }
 
@@ -900,18 +905,13 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
         }
 
         if (val && fs.alt_form) { // 0x or 0b but can't write it yet.
-          if (fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) { need_0x = 'X'; }
+          if (fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT ||
+              fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER) { need_0x = 'X'; }
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
           else if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) { need_0x = 'B'; }
 #endif
           if (need_0x) { need_0x += fs.case_adjust; }
         }
-      } break;
-
-      case NPF_FMT_SPEC_CONV_POINTER: {
-        cbuf_len =
-          npf_utoa_rev((npf_uint_t)(uintptr_t)va_arg(args, void *), cbuf, 16, 'a' - 'A');
-        need_0x = 'x';
       } break;
 
 #if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1


### PR DESCRIPTION
%p is implementation-defined, so the current implementation is fine.
However, it introduces a default '#'. This is present in other implementations as well, though not all of them.
%p respects width and precision specifiers, as well as flags.
So, it seems inconsistent that it should not respect the presence/absence of '#'.

Before vs after this change:
```
printf("%p"     , NULL);     // "0x0"          vs "0"
printf("%#p"    , NULL);     // "0x0"          vs "0"
printf("%10p"   , NULL);     // "       0x0"   vs "         0"
printf("%#10p"  , NULL);     // "       0x0"   vs "         0"
printf("%010p"  , NULL);     // "0x00000000"   vs "0000000000"
printf("%#010p" , NULL);     // "0x00000000"   vs "0000000000"
printf("%.10p"  , NULL);     // "0x0000000000" vs "0000000000"
printf("%#.10p" , NULL);     // "0x0000000000" vs "0000000000"
printf("%0.10p" , NULL);     // "0x0000000000" vs "0000000000"
printf("%#0.10p", NULL);     // "0x0000000000" vs "0000000000"
printf("%p"     , (void*)1); // "0x1"          vs "1"
printf("%#p"    , (void*)1); // "0x1"          vs "0x1"
printf("%10p"   , (void*)1); // "       0x1"   vs "         1"
printf("%#10p"  , (void*)1); // "       0x1"   vs "       0x1"
printf("%010p"  , (void*)1); // "0x00000001"   vs "0000000001"
printf("%#010p" , (void*)1); // "0x00000001"   vs "0x00000001"
printf("%.10p"  , (void*)1); // "0x0000000001" vs "0000000001"
printf("%#.10p" , (void*)1); // "0x0000000001" vs "0x0000000001"
printf("%0.10p" , (void*)1); // "0x0000000001" vs "0000000001"
printf("%#0.10p", (void*)1); // "0x0000000001" vs "0x0000000001"
```

You could argue that with this change, %p is mostly useless, as it is equivalent to %x with appropriate parameters; however, that's mostly true in any case, and the major benefit of %p is that you don't need a cast to the appropriate integer type (like casting to uintptr_t and using %tx, or casting to (unsigned long) and using %lx, or something else, depending on your platform).

Indeed, it could be easier just to change line 914 from:
```
need_0x = 'x';
```
to
```
if (fs.alt_form) { need_0x = 'x'; }
```
Note that this, just like the current behavior, always adds "0x", whereas the "%x" equivalent proposed in this change omits it when the number is 0 (a very weird corner case required by the standard).

I'd say it could be more logical, and also result in smaller code, to apply the one-line change instead.
Also, this would allow for an easier removal of %p support, which would reduce the code footprint. I'm sure that not everybody has a need for %p.

Also note: if '#' is made optional here, and you accept #288 (making '#'-support optional for NPF), then further work would be needed to completely remove the 'need_0x' logic when '#'-support is disabled.