### PR TITLE
cmake: don't use &&, use multiple COMMAND elements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ function(npf_test name files)
   set(timestamp "${CMAKE_CURRENT_BINARY_DIR}/${name}.timestamp")
   add_custom_target(run_${name} ALL DEPENDS ${timestamp})
   add_custom_command(OUTPUT ${timestamp}
-                     COMMAND ${name} -m && ${CMAKE_COMMAND} -E touch ${timestamp}
+                     COMMAND ${name} -m 
+                     COMMAND ${CMAKE_COMMAND} -E touch ${timestamp}
                      DEPENDS ${name}
                      COMMENT "Running ${name}")
 endfunction()


### PR DESCRIPTION
Just tidying up, no functionality changes