### PR TITLE
Honor field-width / precision for %c and %s

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -393,19 +393,18 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
     case '%': out_spec->conv_spec = NPF_FMT_SPEC_CONV_PERCENT;
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
       out_spec->prec_opt = NPF_FMT_SPEC_OPT_NONE;
+      out_spec->prec = 0;
 #endif
       break;
 
     case 'c': out_spec->conv_spec = NPF_FMT_SPEC_CONV_CHAR;
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
       out_spec->prec_opt = NPF_FMT_SPEC_OPT_NONE;
+      out_spec->prec = 0;
 #endif
       break;
 
     case 's': out_spec->conv_spec = NPF_FMT_SPEC_CONV_STRING;
-#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-      out_spec->leading_zero_pad = 0;
-#endif
       break;
 
     case 'i':
@@ -990,17 +989,13 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     // Compute the field width pad character
     if (fs.field_width_opt != NPF_FMT_SPEC_OPT_NONE) {
-      if (fs.leading_zero_pad) { // '0' flag is only legal with numeric types
-        if ((fs.conv_spec != NPF_FMT_SPEC_CONV_STRING) &&
-            (fs.conv_spec != NPF_FMT_SPEC_CONV_CHAR) &&
-            (fs.conv_spec != NPF_FMT_SPEC_CONV_PERCENT)) {
+      if (fs.leading_zero_pad) { 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-          if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero) {
-            pad_c = ' ';
-          } else
+        if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero) {
+          pad_c = ' ';
+        } else
 #endif
-          { pad_c = '0'; }
-        }
+        { pad_c = '0'; }
       } else { pad_c = ' '; }
     }
 #endif

--- a/tests/unit_parse_format_spec.cc
+++ b/tests/unit_parse_format_spec.cc
@@ -369,9 +369,9 @@ TEST_CASE("npf_parse_format_spec") {
       REQUIRE(spec.conv_spec == NPF_FMT_SPEC_CONV_STRING);
     }
 
-    SUBCASE("s clears leading 0") {
+    SUBCASE("s preserves leading 0") {
       REQUIRE(npf_parse_format_spec("%0s", &spec) == 3);
-      REQUIRE(!spec.leading_zero_pad);
+      REQUIRE(spec.leading_zero_pad);
     }
 
     SUBCASE("string negative left-justify field width") {

--- a/tests/unit_vpprintf.cc
+++ b/tests/unit_vpprintf.cc
@@ -263,14 +263,14 @@ TEST_CASE("npf_vpprintf") {
     REQUIRE(r.String() == std::string{"-1"});
   }
 
-  SUBCASE("leading zero-pad flag does nothing on char (undefined)") {
-    REQUIRE(npf_pprintf(r.PutC, &r, "%010c", 'A') == 1);
-    REQUIRE(r.String() == std::string{"A"});
+  SUBCASE("leading zero-pad flag is honored for char (undefined)") {
+    REQUIRE(npf_pprintf(r.PutC, &r, "%010c", 'A') == 10);
+    REQUIRE(r.String() == std::string{"000000000A"});
   }
 
-  SUBCASE("leading zero-pad flag does nothing on string (undefined)") {
-    REQUIRE(npf_pprintf(r.PutC, &r, "%0s", "ABCD") == 4);
-    REQUIRE(r.String() == std::string{"ABCD"});
+  SUBCASE("leading zero-pad flag is honored for string (undefined)") {
+    REQUIRE(npf_pprintf(r.PutC, &r, "%05s", "ABCD") == 5);
+    REQUIRE(r.String() == std::string{"0ABCD"});
   }
 
   SUBCASE("alternative flag: hex doesn't prepend 0x if value is 0") {


### PR DESCRIPTION
It's undefined by the spec but less surprising this way, and less code. This PR is a reimplementation of https://github.com/charlesnicholson/nanoprintf/pull/292 by @stefano-zanotti-88 with some test fixup.