### PR TITLE
added test checks about the length of strings

### DIFF
--- a/tests/conformance.cc
+++ b/tests/conformance.cc
@@ -38,19 +38,21 @@ namespace {
 void require_conform(const std::string& expected, char const *fmt, ...) {
   char buf[256];
 
+  int n_sys;
   std::string sys_printf_result; {
     va_list args;
     va_start(args, fmt);
-    vsnprintf(buf, sizeof(buf), fmt, args);
+    n_sys = vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
     buf[sizeof(buf)-1] = '\0';
     sys_printf_result = buf;
   }
 
+  int n_npf;
   std::string npf_result; {
     va_list args;
     va_start(args, fmt);
-    npf_vsnprintf(buf, sizeof(buf), fmt, args);
+    n_npf = npf_vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
     buf[sizeof(buf)-1] = '\0';
     npf_result = buf;
@@ -58,6 +60,12 @@ void require_conform(const std::string& expected, char const *fmt, ...) {
 
   REQUIRE(sys_printf_result == expected);
   REQUIRE(npf_result == expected);
+  // by transitivity, we fail whenever any of the four lengths does not agree
+  // (npf string, npf ret value, sys string, sys ret value)
+  REQUIRE(n_npf >= 0);
+  REQUIRE(n_npf == n_sys);
+  REQUIRE(n_npf == npf_result.length());
+  REQUIRE(n_npf == sys_printf_result.length()); // remove this, since we already directly compare the two strings?
 }
 }
 


### PR DESCRIPTION
Adds checks about the length of the produced string, and the size reported as the return value.
Also checks it against the return value of the sys printf.

This is just an idea. I haven't actually compiled the NPF tests (usual problems).
It should also be extended to other test files.

Adding these checks caught some issues. I've run those checks on (a replica of) conformance.cc only, not on the test cases in paland.cc nor the other test suites.
Issues:
`require_conform(output, "%c", i);`: prints "", returns 1
`require_conform("", "%+c", 0);`: prints "", returns 1
`require_conform(buf, "%p", p);`: due to implementation-defined behavior; might be fixed in your latest commits (about optional "0x" in %p), but we should check
`require_conform("0.00390625", "%.8Lf", (long double)0.00390625);`: my own sys printf prints "0.00000000". Maybe something to look out for when comparing npf to sys.
`require_conform("-0.00390625", "%.8Lf", (long double)-0.00390625);`: my own sys printf prints "0.00000000". Maybe something to look out for when comparing npf to sys

Note that printing '\0' is UB.
I've seen this behavior:
```
printf("a%cx", '\0'); // NPF: "ax", returns 3
printf("a%cx", '\0'); // GCC/clang: "ax", returns 3
printf("a%cx", '\0'); // other: "a", returns 3 (presumably actually writes "a\0x" in the buffer)
```

A test like `printf("a%cx", '\0')` should be added to our tests -- I'm thinking of a new file gathering all UB/IB, maybe the nan test cases could be moved there as well.