### PR TITLE
Shrink size roughtly 20%: General updates to the ASCII/FLOAT/INTEGER formatters and buffer handling

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 * [Dean T](https://github.com/deanoburrito)
 * [Oskars Rubenis](https://github.com/Okarss)
 * [Ka Wing Li](https://github.com/kingiler)
+* [Fran Cap](https://github.com/fran-cap/)

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ UNIT_SRCS := tests/unit_parse_format_spec.cc \
              tests/unit_ftoa_rev_32.cc \
              tests/unit_ftoa_rev_64.cc \
              tests/unit_utoa_rev.cc \
+             tests/unit_utoa_rev_divfree.cc \
              tests/unit_snprintf.cc \
              tests/unit_snprintf_safe_empty.cc \
              tests/unit_vpprintf.cc

--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ nanoprintf has the following static configuration flags.
 * `NANOPRINTF_USE_FLOAT_SINGLE_PRECISION`: Set to `0` or `1`. Uses `float` instead of `double` for all float math. Requires `NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=1` and `NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=1`.
 * `NANOPRINTF_VISIBILITY_STATIC`: Optional define. Marks prototypes as `static` to sandbox nanoprintf.
 * `NANOPRINTF_CONFIG_FILE`: Optional define. When set (e.g. `-DNANOPRINTF_CONFIG_FILE="\"my_npf_config.h\""` or `-DNANOPRINTF_CONFIG_FILE="<my_npf_config.h>"`), nanoprintf will `#include` the specified file at the top of `nanoprintf.h`, before any configuration-dependent code. This provides a FreeRTOS-style mechanism to ensure every translation unit sees the same configuration without requiring a wrapper header.
+* `NANOPRINTF_USE_DIVISION_FREE_CONVERSION`: Set to `0` or `1`. Enables extracting digits without integer division or modulo operations.
 
 If no configuration flags are specified, nanoprintf will default to "reasonable" embedded values in an attempt to be helpful: floats are enabled, but writeback, binary, and large formatters are disabled. If any configuration flags are explicitly specified, nanoprintf requires that all flags are explicitly specified.
 
 If a disabled format specifier feature is used, no conversion will occur and the format specifier string simply will be printed instead.
+
+Note, unrecognized conversion specifiers are undefined behavior. Nanoprintf folds the conversion specifier character to lowercase during parsing, so an unsupported uppercase specifier is treated as its lowercase counterpart: `%D` behaves like `%d`, `%S` like `%s`, `%P` prints a pointer, and so on, with uppercase output wherever case applies (hex digits, `INF`/`NAN`). Earlier versions of nanoprintf printed unrecognized specifiers literally instead; do not rely on either behavior.
 
 ### Floating-Point Conversion
 nanoprintf has the following floating-point specific configuration defines.
@@ -180,6 +183,12 @@ The `%e`/`%E` and `%g`/`%G` specifiers are parsed but not formatted. If used, th
 When `NANOPRINTF_USE_FLOAT_SINGLE_PRECISION` is set to `1`, nanoprintf uses `float` instead of `double` for all internal floating-point math. This is useful on MCUs with single-precision FPUs (e.g. Cortex-M4) where enabling double-precision float formatting would otherwise pull in expensive soft-float library routines.
 
 C's variadic calling convention promotes `float` arguments to `double` when they cross a function boundary. To prevent this, single-precision mode wraps `float` and `double` arguments in a small struct (`npf_float_t`) at the call site, before they reach `va_start`. This wrapping is automatic: `npf_snprintf` and `npf_pprintf` are macros that apply `NPF_MAP_ARGS` to all arguments, which wraps any `float` or `double` values while passing all other types through unchanged.
+
+### Division-Free Conversion
+
+When `NANOPRINTF_USE_DIVISION_FREE_CONVERSION` is set to `1`, nanoprintf performs all digit extraction without integer division or modulo operations: octal, hex and decimal digits are extracted with shifts, adds, and masks.
+
+On cores without a hardware divider (e.g. Cortex-M0), integer division compiles to a call into a software-divide helper routine; enabling this flag keeps those helpers out of the link, shrinking the binary. On cores with hardware divide instructions (e.g. Cortex-M4), plain division is usually smaller, so leave the flag off there.
 
 #### Link-time ABI safety
 

--- a/build.py
+++ b/build.py
@@ -21,6 +21,7 @@ _UNIT_SRCS = [
     "tests/unit_ftoa_rev_32.cc",
     "tests/unit_ftoa_rev_64.cc",
     "tests/unit_utoa_rev.cc",
+    "tests/unit_utoa_rev_divfree.cc",
     "tests/unit_snprintf.cc",
     "tests/unit_snprintf_safe_empty.cc",
     "tests/unit_vpprintf.cc",

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -133,12 +133,8 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc,
   #define NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER 0
 #endif
 
-// Optional flag, defaults to 0 if not explicitly configured. On cores without a
-// hardware divider (e.g. ARMv6-M, or RISC-V without the M extension), libgcc's
-// __udivsi3 costs ~270 bytes; division-free digit extraction (shift/mask for
-// octal/hex, exact shift-add divide-by-10 for decimal) keeps it out of the link
-// entirely. Enable it explicitly (define to 1) on such targets; leave it off
-// where a hardware divider makes real division smaller.
+// Optional flag, defaults to 0 if not explicitly configured. Extracts digits
+// without integer division; smaller on cores without a hardware divider.
 #ifndef NANOPRINTF_USE_DIVISION_FREE_CONVERSION
   #define NANOPRINTF_USE_DIVISION_FREE_CONVERSION 0
 #endif
@@ -363,6 +359,33 @@ enum {
 #endif
 };
 
+// Assert range order/comparisons to enforce C standard ordering
+#define NPF_CONV_ORDER_ASSERT(NAME, COND) \
+  typedef char npf_assert_##NAME[(COND) ? 1 : -1]
+NPF_CONV_ORDER_ASSERT(text_convs_before_numeric,
+  (NPF_FMT_SPEC_CONV_PERCENT < NPF_FMT_SPEC_CONV_SIGNED_INT) &&
+  (NPF_FMT_SPEC_CONV_CHAR < NPF_FMT_SPEC_CONV_SIGNED_INT) &&
+  (NPF_FMT_SPEC_CONV_STRING < NPF_FMT_SPEC_CONV_SIGNED_INT));
+#if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
+NPF_CONV_ORDER_ASSERT(int_convs_contiguous,
+  NPF_FMT_SPEC_CONV_UNSIGNED_INT == NPF_FMT_SPEC_CONV_SIGNED_INT + 4);
+#else
+NPF_CONV_ORDER_ASSERT(int_convs_contiguous,
+  NPF_FMT_SPEC_CONV_UNSIGNED_INT == NPF_FMT_SPEC_CONV_SIGNED_INT + 3);
+#endif
+NPF_CONV_ORDER_ASSERT(pointer_after_int_convs,
+  NPF_FMT_SPEC_CONV_POINTER > NPF_FMT_SPEC_CONV_UNSIGNED_INT);
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
+NPF_CONV_ORDER_ASSERT(float_convs_last,
+  NPF_FMT_SPEC_CONV_FLOAT_DEC > NPF_FMT_SPEC_CONV_WRITEBACK);
+#else
+NPF_CONV_ORDER_ASSERT(float_convs_last,
+  NPF_FMT_SPEC_CONV_FLOAT_DEC > NPF_FMT_SPEC_CONV_POINTER);
+#endif
+#endif
+#undef NPF_CONV_ORDER_ASSERT
+
 typedef struct npf_format_spec {
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
   int field_width;
@@ -574,7 +597,7 @@ static NPF_FORCE_INLINE int npf_parse_format_spec(char const *format,
 }
 
 #if NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1
-// Exact n/10 for any uint32_t without hardware division (Hacker's Delight).
+// Calculate div by 10 justing a shift and mask to avoid using hw div operands
 static NPF_NOINLINE uint32_t npf_div10(uint32_t n) {
   uint32_t q = (n >> 1) + (n >> 2);
   q += q >> 4;
@@ -589,9 +612,7 @@ static NPF_NOINLINE char *npf_utoa_rev_end(
     npf_uint_t val, char *buf, uint_fast8_t base, char case_adj) {
 #if (NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1) || \
     ((NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1) && NPF_UINT_IS_WIDE)
-  // For values that don't fit in 32 bits, shift-and-subtract divmod avoids
-  // pulling in __udivmoddi4 (~784 B on ARM EABI). Slow but tiny; the 32-bit
-  // fast path below handles all typical values.
+  // Use shift and subtract here to avoid hw div operation
   while (val > 0xFFFFFFFFu) {
     npf_uint_t q = 0, r = 0;
     for (int i = (int)(sizeof(val) * 8) - 1; i >= 0; --i) {
@@ -701,9 +722,8 @@ static NPF_FORCE_INLINE npf_real_bin_t npf_real_to_int_rep(npf_real_t f) {
 }
 
 #if NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1
-// Variable shifts of 64-bit values call __aeabi_llsl/__aeabi_llsr on cores
-// without 64-bit shifters (e.g. ARMv6-M); one-bit-at-a-time loops keep those
-// helpers out of the link. 32-bit npf_real_bin_t shifts stay native.
+// Variable shifts of 64-bit values call sw helpers on archs
+// without 64-bit shifters. Perfer 1 bit shits to keep in 32 bit word spce.
 static NPF_FORCE_INLINE npf_real_bin_t npf_bin_shr(npf_real_bin_t v, int_fast8_t s) {
   if (sizeof(v) > sizeof(uint32_t)) { while (s--) { v >>= 1; } return v; }
   return (npf_real_bin_t)(v >> s);
@@ -720,6 +740,8 @@ static NPF_FORCE_INLINE npf_real_bin_t npf_bin_shl(npf_real_bin_t v, int_fast8_t
 #endif
 
 static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) {
+  // Packed reversed specials "NAN"/"FNI"(inf)/"RRE"(err), selected by offset.
+  static char const specials[] = "NAN\0FNI\0RRE";
   char const *ret = NULL;
   npf_real_bin_t bin = npf_real_to_int_rep(f);
 
@@ -729,9 +751,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
 
   bin &= ((npf_real_bin_t)0x1 << NPF_REAL_MAN_BITS) - 1;
   if (!((unsigned)(exp + 1) & NPF_REAL_EXP_MASK)) { // special value
-    // Packed reversed specials "NAN"/"FNI"(inf)/"RRE"(err), indexed by offset.
-    // Cast this so we dont throw a warning for the + operation
-    ret = (char const *)"NAN\0FNI\0RRE" + ((bin) ? 0 : 4);
+    ret = specials + (bin ? 0 : 4);
     goto exit;
   }
   if (spec->prec > (NANOPRINTF_CONVERSION_BUFFER_SIZE - 2)) { goto exit; }
@@ -890,7 +910,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
 
   return (int)end;
 exit:
-  if (!ret) { ret = (char const *)"NAN\0FNI\0RRE" + 8; }
+  if (!ret) { ret = specials + 8; }
   uint_fast8_t i = 0;
   do { buf[i] = (char)(ret[i] + spec->case_adjust); } while (ret[++i]);
   return -(int)i;
@@ -1024,13 +1044,12 @@ static void npf_bufputc(int c, void *ctx) {
 }
 
 #define NPF_PUTC(VAL) do { pc((int)(VAL), pc_ctx); ++npf_n; } while (0)
-// Emission inside a conversion: the spec's total length is added to npf_n in bulk.
 #define NPF_PUT(VAL) do { pc((int)(VAL), pc_ctx); } while (0)
 
 #define NPF_EXTRACT(DST, MOD, CAST_TO, EXTRACT_AS) \
   case NPF_FMT_SPEC_LEN_MOD_##MOD: DST = (CAST_TO)va_arg(args, EXTRACT_AS); break
 
-// When sizeof(long) == sizeof(int) (any ILP32 ABI, e.g. ARM EABI / Win32 / Win64),
+// When sizeof(long) == sizeof(int)
 // va_arg(*args, long) and va_arg(*args, int) read the same bits, so the LONG
 // case can fall into the int-promotion default.
 #if LONG_MAX == INT_MAX
@@ -1038,10 +1057,6 @@ static void npf_bufputc(int c, void *ctx) {
 #else
   #define NPF_LONG_IS_INT 0
 #endif
-
-
-#define NPF_WRITEBACK(MOD, TYPE) \
-  case NPF_FMT_SPEC_LEN_MOD_##MOD: *(va_arg(args, TYPE *)) = (TYPE)npf_n; break
 
 int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
   npf_format_spec_t fs;
@@ -1128,7 +1143,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if NANOPRINTF_USE_FLOAT_SINGLE_PRECISION == 1
       val = va_arg(args, npf_float_t).val;
 #elif LDBL_MANT_DIG == DBL_MANT_DIG
-      // long double has the same representation as double (e.g. ARM EABI);
+      // long double has the same representation as double
       // no need to branch on the 'L' length modifier.
       val = va_arg(args, double);
 #else
@@ -1377,6 +1392,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
     // this loop body only executes for left-justified specifiers.
     while (field_pad-- > 0) { NPF_PUT(pad_c); }
 #endif
+    // NPF_PUT emissions don't tally npf_n; add the conversion's total length in bulk.
     npf_n += spec_len;
   }
 
@@ -1386,6 +1402,9 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #undef NPF_PUTC
 #undef NPF_PUT
 #undef NPF_EXTRACT
+#undef NPF_LONG_IS_INT
+#undef NPF_BIN_SHR
+#undef NPF_BIN_SHL
 
 int npf_vsnprintf(char * NPF_RESTRICT buffer,
                   size_t bufsz,

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -729,7 +729,9 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
 
   bin &= ((npf_real_bin_t)0x1 << NPF_REAL_MAN_BITS) - 1;
   if (!((unsigned)(exp + 1) & NPF_REAL_EXP_MASK)) { // special value
-    ret = "NAN\0FNI\0RRE" + ((bin) ? 0 : 4);
+    // Packed reversed specials "NAN"/"FNI"(inf)/"RRE"(err), indexed by offset.
+    // Cast this so we dont throw a warning for the + operation
+    ret = (char const *)"NAN\0FNI\0RRE" + ((bin) ? 0 : 4);
     goto exit;
   }
   if (spec->prec > (NANOPRINTF_CONVERSION_BUFFER_SIZE - 2)) { goto exit; }
@@ -888,7 +890,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
 
   return (int)end;
 exit:
-  if (!ret) { ret = "NAN\0FNI\0RRE" + 8; }
+  if (!ret) { ret = (char const *)"NAN\0FNI\0RRE" + 8; }
   uint_fast8_t i = 0;
   do { buf[i] = (char)(ret[i] + spec->case_adjust); } while (ret[++i]);
   return -(int)i;

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -1185,6 +1185,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 
       if (fs.conv_spec == NPF_FMT_SPEC_CONV_SIGNED_INT) {
         npf_int_t sval = 0;
+#if !NPF_LONG_IS_INT || NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
         switch (fs.length_modifier) {
 #if !NPF_LONG_IS_INT
           NPF_EXTRACT(sval, LONG, long, long);
@@ -1195,15 +1196,20 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           NPF_EXTRACT(sval, LARGE_SIZET, npf_ssize_t, npf_ssize_t);
           NPF_EXTRACT(sval, LARGE_PTRDIFFT, ptrdiff_t, ptrdiff_t);
 #endif
-          default: {
+          default:
+#endif
+          {
             int v = va_arg(args, int);
 #if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
             if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_SHORT) { v = (short)v; }
             else if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_CHAR) { v = (signed char)v; }
 #endif
             sval = v;
-          } break;
+          }
+#if !NPF_LONG_IS_INT || NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+          break;
         }
+#endif
         sign_c = (sval < 0) ? '-' : fs.prepend;
         val = (npf_uint_t)sval;
         if (sval < 0) { val = 0 - val; }
@@ -1212,6 +1218,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
           val = (npf_uint_t)(uintptr_t)va_arg(args, void *);
           base = 16u;
         } else {
+#if !NPF_LONG_IS_INT || NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           switch (fs.length_modifier) {
 #if !NPF_LONG_IS_INT
             NPF_EXTRACT(val, LONG, unsigned long, unsigned long);
@@ -1222,15 +1229,20 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
             NPF_EXTRACT(val, LARGE_SIZET, size_t, size_t);
             NPF_EXTRACT(val, LARGE_PTRDIFFT, npf_uptrdiff_t, npf_uptrdiff_t);
 #endif
-            default: {
+            default:
+#endif
+            {
               unsigned v = va_arg(args, unsigned);
 #if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
               if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_SHORT) { v = (unsigned short)v; }
               else if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_CHAR) { v = (unsigned char)v; }
 #endif
               val = v;
-            } break;
+            }
+#if !NPF_LONG_IS_INT || NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+            break;
           }
+#endif
           if (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) { base = 8u; }
           else if (fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) { base = 16u; }
         }

--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -133,6 +133,16 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc,
   #define NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER 0
 #endif
 
+// Optional flag, defaults to 0 if not explicitly configured. On cores without a
+// hardware divider (e.g. ARMv6-M, or RISC-V without the M extension), libgcc's
+// __udivsi3 costs ~270 bytes; division-free digit extraction (shift/mask for
+// octal/hex, exact shift-add divide-by-10 for decimal) keeps it out of the link
+// entirely. Enable it explicitly (define to 1) on such targets; leave it off
+// where a hardware divider makes real division smaller.
+#ifndef NANOPRINTF_USE_DIVISION_FREE_CONVERSION
+  #define NANOPRINTF_USE_DIVISION_FREE_CONVERSION 0
+#endif
+
 // If anything's been configured, everything must be configured.
 #ifndef NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS
   #error NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS must be #defined to 0 or 1
@@ -378,18 +388,20 @@ typedef struct npf_format_spec {
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
   typedef intmax_t npf_int_t;
   typedef uintmax_t npf_uint_t;
+  #define NPF_UINT_IS_WIDE 1 // uintmax_t is at least 64 bits
 #elif ULONG_MAX > UINTPTR_MAX
   typedef long npf_int_t;
   typedef unsigned long npf_uint_t;
+  #define NPF_UINT_IS_WIDE (ULONG_MAX > 0xFFFFFFFFu)
 #else
   typedef intptr_t npf_int_t;
   typedef uintptr_t npf_uint_t;
+  #define NPF_UINT_IS_WIDE (UINTPTR_MAX > 0xFFFFFFFFu)
 #endif
 
 typedef struct npf_bufputc_ctx {
-  char *dst;
-  size_t len;
-  size_t cur;
+  char *dst;       // moving cursor; advances on each write while len > 0.
+  size_t len;      // remaining capacity; decrements on each successful write.
 } npf_bufputc_ctx_t;
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
@@ -402,27 +414,30 @@ typedef struct npf_bufputc_ctx {
   #include <intrin.h>
 #endif
 
-static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec) {
+// Returns a pointer one past the last consumed character on success, null on
+// failure. A pointer return inlines into npf_vpprintf with smaller code than
+// a length return (the caller continues from the returned cursor directly).
+static char const *npf_parse_format_spec_end(char const *format,
+                                             npf_format_spec_t *out_spec) {
   char const *cur = format;
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
   out_spec->left_justified = 0;
   out_spec->leading_zero_pad = 0;
 #endif
-  out_spec->case_adjust = 'a' - 'A'; // lowercase
   out_spec->prepend = 0;
 #if NANOPRINTF_USE_ALT_FORM_FLAG == 1
   out_spec->alt_form = 0;
 #endif
 
-  while (*++cur) { // cur points at the leading '%' character
-    switch (*cur) { // Optional flags
+  for (;;) { // cur points at the leading '%' character
+    switch (*++cur) { // Optional flags; '\0' exits via default.
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
       case '-': out_spec->left_justified = '-'; continue;
       case '0': out_spec->leading_zero_pad = 1; continue;
 #endif
-      case '+': out_spec->prepend = '+'; continue;
-      case ' ': if (out_spec->prepend == 0) { out_spec->prepend = ' '; } continue;
+      case '+':
+      case ' ': if (out_spec->prepend != '+') { out_spec->prepend = *cur; } continue;
 #if NANOPRINTF_USE_ALT_FORM_FLAG == 1
       case '#': out_spec->alt_form = '#'; continue;
 #endif
@@ -438,7 +453,7 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
     out_spec->field_width_opt = NPF_FMT_SPEC_OPT_STAR;
     ++cur;
   } else {
-    while ((*cur >= '0') && (*cur <= '9')) {
+    while ((unsigned)(*cur - '0') < 10u) {
       out_spec->field_width_opt = NPF_FMT_SPEC_OPT_LITERAL;
       out_spec->field_width = (out_spec->field_width * 10) + (*cur++ - '0');
     }
@@ -459,14 +474,13 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
       } else {
         out_spec->prec_opt = NPF_FMT_SPEC_OPT_LITERAL;
       }
-      while ((*cur >= '0') && (*cur <= '9')) {
+      while ((unsigned)(*cur - '0') < 10u) {
         out_spec->prec = (out_spec->prec * 10) + (*cur++ - '0');
       }
     }
   }
 #endif
 
-  uint_fast8_t tmp_conv = NPF_FMT_SPEC_CONV_NONE;
   out_spec->length_modifier = NPF_FMT_SPEC_LEN_MOD_NONE;
   switch (*cur++) { // Length modifier
 #if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
@@ -498,85 +512,124 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
     default: --cur; break;
   }
 
-  switch (*cur++) { // Conversion specifier
-    case '%': out_spec->conv_spec = NPF_FMT_SPEC_CONV_PERCENT;
-      break;
-
-    case 'c': out_spec->conv_spec = NPF_FMT_SPEC_CONV_CHAR;
-      break;
-
-    case 's': out_spec->conv_spec = NPF_FMT_SPEC_CONV_STRING;
-      break;
-
-    case 'i':
-    case 'd': tmp_conv = NPF_FMT_SPEC_CONV_SIGNED_INT; goto finish;
-    case 'o': tmp_conv = NPF_FMT_SPEC_CONV_OCTAL; goto finish;
-    case 'u': tmp_conv = NPF_FMT_SPEC_CONV_UNSIGNED_INT; goto finish;
-    case 'X': out_spec->case_adjust = 0;
-    case 'x': tmp_conv = NPF_FMT_SPEC_CONV_HEX_INT; goto finish;
-    finish:
-      out_spec->conv_spec = (uint8_t)tmp_conv;
-      break;
-
-#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
-    case 'F': out_spec->case_adjust = 0;
-    case 'f':
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_FLOAT_DEC;
-      break;
-
-    case 'E': out_spec->case_adjust = 0;
-    case 'e':
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_FLOAT_SCI;
-      break;
-
-    case 'G': out_spec->case_adjust = 0;
-    case 'g':
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_FLOAT_SHORTEST;
-      break;
-
-#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
-    case 'A': out_spec->case_adjust = 0;
-    case 'a':
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_FLOAT_HEX;
-      break;
+  // Conversion specifier. Look up the conv_spec from a 24-byte table indexed by
+  // (lowercased letter - 'a'). '%' is handled out-of-line since it's the only
+  // non-letter conversion. case_adjust gets bit 5 of the original char.
+  char const c = *cur++;
+  uint_fast8_t cs;
+  if (c == '%') {
+    cs = NPF_FMT_SPEC_CONV_PERCENT;
+  } else {
+    static const uint8_t lookup[24] = {
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1 && NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
+      NPF_FMT_SPEC_CONV_FLOAT_HEX,      // 'a'
+#else
+      0,                                 // 'a'
 #endif
-#endif
-
-#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
-    case 'n':
-      // todo: reject string if flags or width or precision exist
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_WRITEBACK;
-      break;
-#endif
-
-    case 'p':
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_POINTER;
-      break;
-
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
-    case 'B':
-      out_spec->case_adjust = 0;
-    case 'b':
-      out_spec->conv_spec = NPF_FMT_SPEC_CONV_BINARY;
-      break;
+      NPF_FMT_SPEC_CONV_BINARY,          // 'b'
+#else
+      0,                                 // 'b'
 #endif
-
-    default: return 0;
+      NPF_FMT_SPEC_CONV_CHAR,            // 'c'
+      NPF_FMT_SPEC_CONV_SIGNED_INT,      // 'd'
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+      NPF_FMT_SPEC_CONV_FLOAT_SCI,       // 'e'
+      NPF_FMT_SPEC_CONV_FLOAT_DEC,       // 'f'
+      NPF_FMT_SPEC_CONV_FLOAT_SHORTEST,  // 'g'
+#else
+      0, 0, 0,                           // 'e', 'f', 'g'
+#endif
+      0,                                 // 'h' (length modifier)
+      NPF_FMT_SPEC_CONV_SIGNED_INT,      // 'i'
+      0, 0, 0, 0,                        // 'j', 'k', 'l', 'm'
+#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
+      NPF_FMT_SPEC_CONV_WRITEBACK,       // 'n'
+#else
+      0,                                 // 'n'
+#endif
+      NPF_FMT_SPEC_CONV_OCTAL,           // 'o'
+      NPF_FMT_SPEC_CONV_POINTER,         // 'p'
+      0, 0,                              // 'q', 'r'
+      NPF_FMT_SPEC_CONV_STRING,          // 's'
+      0,                                 // 't'
+      NPF_FMT_SPEC_CONV_UNSIGNED_INT,    // 'u'
+      0, 0,                              // 'v', 'w'
+      NPF_FMT_SPEC_CONV_HEX_INT,         // 'x'
+    };
+    unsigned const idx = (unsigned)((c | 32) - 'a');
+    if (idx >= sizeof(lookup) || !(cs = lookup[idx])) { return NULL; }
   }
+  out_spec->conv_spec = (uint8_t)cs;
+  out_spec->case_adjust = (char)(c & 32); // 32 for lowercase, 0 for uppercase
 
-  return (int)(cur - format);
+  return cur;
 }
 
-static NPF_NOINLINE int npf_utoa_rev(
+// Length-returning facade over npf_parse_format_spec_end; 0 means failure.
+static NPF_FORCE_INLINE int npf_parse_format_spec(char const *format,
+                                                  npf_format_spec_t *out_spec) {
+  char const *const end = npf_parse_format_spec_end(format, out_spec);
+  return end ? (int)(end - format) : 0;
+}
+
+#if NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1
+// Exact n/10 for any uint32_t without hardware division (Hacker's Delight).
+static NPF_NOINLINE uint32_t npf_div10(uint32_t n) {
+  uint32_t q = (n >> 1) + (n >> 2);
+  q += q >> 4;
+  q += q >> 8;
+  q += q >> 16;
+  q >>= 3;
+  return q + ((n - (q * 10u) + 6u) >> 4);
+}
+#endif
+
+static NPF_NOINLINE char *npf_utoa_rev_end(
     npf_uint_t val, char *buf, uint_fast8_t base, char case_adj) {
-  uint_fast8_t n = 0;
-  do {
-    int_fast8_t const d = (int_fast8_t)(val % base);
+#if (NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1) || \
+    ((NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1) && NPF_UINT_IS_WIDE)
+  // For values that don't fit in 32 bits, shift-and-subtract divmod avoids
+  // pulling in __udivmoddi4 (~784 B on ARM EABI). Slow but tiny; the 32-bit
+  // fast path below handles all typical values.
+  while (val > 0xFFFFFFFFu) {
+    npf_uint_t q = 0, r = 0;
+    for (int i = (int)(sizeof(val) * 8) - 1; i >= 0; --i) {
+      r = (r << 1) | ((val >> i) & 1);
+      if (r >= (npf_uint_t)base) { r -= base; q |= (npf_uint_t)1 << i; }
+    }
+    int_fast8_t const d = (int_fast8_t)r;
     *buf++ = (char)(((d < 10) ? '0' : ('A' - 10 + case_adj)) + d);
-    ++n;
-    val /= base;
-  } while (val);
-  return (int)n;
+    val = q;
+  }
+  uint32_t v32 = (uint32_t)val;
+#else
+  npf_uint_t v32 = val;
+#endif
+  do {
+#if NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1
+    int_fast8_t d;
+    if (base == 10u) {
+      uint32_t const q = npf_div10((uint32_t)v32);
+      d = (int_fast8_t)((uint32_t)v32 - (q * 10u));
+      v32 = q;
+    } else { // base 8 or 16: shift and mask
+      d = (int_fast8_t)(v32 & (base - 1u));
+      v32 >>= (base + 16u) >> 3; // 8 -> 3, 16 -> 4
+    }
+#else
+    int_fast8_t const d = (int_fast8_t)(v32 % base);
+    v32 /= base;
+#endif
+    *buf++ = (char)(((d < 10) ? '0' : ('A' - 10 + case_adj)) + d);
+  } while (v32);
+  return buf;
+}
+
+// Length-returning facade over npf_utoa_rev_end.
+static NPF_FORCE_INLINE int npf_utoa_rev(
+    npf_uint_t val, char *buf, uint_fast8_t base, char case_adj) {
+  return (int)(npf_utoa_rev_end(val, buf, base, case_adj) - buf);
 }
 
 #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
@@ -647,6 +700,25 @@ static NPF_FORCE_INLINE npf_real_bin_t npf_real_to_int_rep(npf_real_t f) {
   return bin;
 }
 
+#if NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1
+// Variable shifts of 64-bit values call __aeabi_llsl/__aeabi_llsr on cores
+// without 64-bit shifters (e.g. ARMv6-M); one-bit-at-a-time loops keep those
+// helpers out of the link. 32-bit npf_real_bin_t shifts stay native.
+static NPF_FORCE_INLINE npf_real_bin_t npf_bin_shr(npf_real_bin_t v, int_fast8_t s) {
+  if (sizeof(v) > sizeof(uint32_t)) { while (s--) { v >>= 1; } return v; }
+  return (npf_real_bin_t)(v >> s);
+}
+static NPF_FORCE_INLINE npf_real_bin_t npf_bin_shl(npf_real_bin_t v, int_fast8_t s) {
+  if (sizeof(v) > sizeof(uint32_t)) { while (s--) { v <<= 1; } return v; }
+  return (npf_real_bin_t)(v << s);
+}
+  #define NPF_BIN_SHR(V, S) npf_bin_shr((V), (int_fast8_t)(S))
+  #define NPF_BIN_SHL(V, S) npf_bin_shl((V), (int_fast8_t)(S))
+#else
+  #define NPF_BIN_SHR(V, S) ((npf_real_bin_t)((V) >> (S)))
+  #define NPF_BIN_SHL(V, S) ((npf_real_bin_t)((V) << (S)))
+#endif
+
 static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) {
   char const *ret = NULL;
   npf_real_bin_t bin = npf_real_to_int_rep(f);
@@ -656,8 +728,8 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
     (npf_ftoa_exp_t)((npf_ftoa_exp_t)(bin >> NPF_REAL_MAN_BITS) & NPF_REAL_EXP_MASK);
 
   bin &= ((npf_real_bin_t)0x1 << NPF_REAL_MAN_BITS) - 1;
-  if (exp == (npf_ftoa_exp_t)NPF_REAL_EXP_MASK) { // special value
-    ret = (bin) ? "NAN" : "FNI";
+  if (!((unsigned)(exp + 1) & NPF_REAL_EXP_MASK)) { // special value
+    ret = "NAN\0FNI\0RRE" + ((bin) ? 0 : 4);
     goto exit;
   }
   if (spec->prec > (NANOPRINTF_CONVERSION_BUFFER_SIZE - 2)) { goto exit; }
@@ -686,25 +758,38 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
         (int_fast8_t)((exp > NPF_FTOA_SHIFT_BITS) ? (int)NPF_FTOA_SHIFT_BITS : exp);
       npf_ftoa_exp_t exp_i = (npf_ftoa_exp_t)(exp - shift_i);
       shift_i = (int_fast8_t)(NPF_REAL_MAN_BITS - shift_i);
-      man_i = (npf_ftoa_man_t)(bin >> shift_i);
+      if (shift_i) {
+        npf_real_bin_t const bin_i = NPF_BIN_SHR(bin, shift_i - 1);
+        carry = (uint_fast8_t)(bin_i & 0x1);
+        man_i = (npf_ftoa_man_t)(bin_i >> 1);
+      } else {
+        man_i = (npf_ftoa_man_t)bin;
+      }
 
       if (exp_i) {
-        if (shift_i) {
-          carry = (bin >> (shift_i - 1)) & 0x1;
-        }
         exp = NPF_REAL_MAN_BITS; // invalidate the fraction part
       }
 
       // Scale the exponent from base-2 to base-10.
       for (; exp_i; --exp_i) {
-        if (!(man_i & ((npf_ftoa_man_t)0x1 << (NPF_FTOA_MAN_BITS - 1)))) {
-          man_i = (npf_ftoa_man_t)(man_i << 1);
-          man_i = (npf_ftoa_man_t)(man_i | carry); carry = 0;
+        if (!(man_i >> (NPF_FTOA_MAN_BITS - 1))) {
+          man_i = (npf_ftoa_man_t)((man_i << 1) | carry); carry = 0;
         } else {
           if (dec >= NANOPRINTF_CONVERSION_BUFFER_SIZE) { goto exit; }
           buf[dec++] = '0';
-          carry = (((uint_fast8_t)(man_i % 5) + carry) > 2);
-          man_i /= 5;
+#if NANOPRINTF_USE_DIVISION_FREE_CONVERSION == 1
+          if (sizeof(man_i) <= sizeof(uint32_t)) { // n/5 = 2*(n/10) + (n%10 >= 5)
+            uint32_t const q = npf_div10((uint32_t)man_i);
+            uint_fast8_t r = (uint_fast8_t)((uint32_t)man_i - (q * 10u));
+            man_i = (npf_ftoa_man_t)(q * 2u);
+            if (r >= 5u) { r = (uint_fast8_t)(r - 5u); ++man_i; }
+            carry = (uint_fast8_t)((r + carry + 1u) >> 2);
+          } else
+#endif
+          {
+            carry = (uint_fast8_t)(((uint_fast8_t)(man_i % 5) + carry + 1u) >> 2);
+            man_i /= 5;
+          }
         }
       }
     } else {
@@ -712,11 +797,21 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
     }
     end = dec;
 
-    do { // Print the integer
-      if (end >= NANOPRINTF_CONVERSION_BUFFER_SIZE) { goto exit; }
-      buf[end++] = (char)('0' + (char)(man_i % 10));
-      man_i /= 10;
-    } while (man_i);
+    // Print the integer. A 32-bit man_i has at most 10 decimal digits, so one
+    // up-front capacity check replaces the per-digit check and npf_utoa_rev
+    // becomes the shared decimal emitter. (Conservative: a value needing fewer
+    // digits than the remaining capacity in the last 9 bytes now reports ERR.)
+    if ((sizeof(npf_ftoa_man_t) <= sizeof(uint32_t)) &&
+        (sizeof(npf_uint_t) >= sizeof(uint32_t))) {
+      if (end > NANOPRINTF_CONVERSION_BUFFER_SIZE - 10) { goto exit; }
+      end = (npf_ftoa_dec_t)(npf_utoa_rev_end((npf_uint_t)man_i, buf + end, 10, 0) - buf);
+    } else { // man_i may be wider than npf_uint_t: emit in place
+      do {
+        if (end >= NANOPRINTF_CONVERSION_BUFFER_SIZE) { goto exit; }
+        buf[end++] = (char)('0' + (char)(man_i % 10));
+        man_i /= 10;
+      } while (man_i);
+    }
   }
 
   { // Fraction part
@@ -727,7 +822,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
       int_fast8_t shift_f = (int_fast8_t)((exp < 0) ? -1 : exp);
       npf_ftoa_exp_t exp_f = (npf_ftoa_exp_t)(exp - shift_f);
       npf_real_bin_t bin_f =
-        bin << ((NPF_REAL_BIN_BITS - NPF_REAL_MAN_BITS) + shift_f);
+        NPF_BIN_SHL(bin, (NPF_REAL_BIN_BITS - NPF_REAL_MAN_BITS) + shift_f);
 
       // This if-else statement can be completely optimized at compile time.
       if (NPF_REAL_BIN_BITS > NPF_FTOA_MAN_BITS) {
@@ -785,16 +880,17 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, npf_real_t f) 
   for (; carry; ++dec) {
     if (dec >= NANOPRINTF_CONVERSION_BUFFER_SIZE) { goto exit; }
     if (dec >= end) { buf[end++] = '0'; }
-    if (buf[dec] == '.') { continue; }
-    carry = (buf[dec] == '9');
-    buf[dec] = (char)(carry ? '0' : (buf[dec] + 1));
+    char const c = buf[dec];
+    if (c == '.') { continue; }
+    if (c == '9') { buf[dec] = '0'; }
+    else { buf[dec] = (char)(c + 1); carry = 0; }
   }
 
   return (int)end;
 exit:
-  if (!ret) { ret = "RRE"; }
-  uint_fast8_t i;
-  for (i = 0; ret[i]; ++i) { buf[i] = (char)(ret[i] + spec->case_adjust); }
+  if (!ret) { ret = "NAN\0FNI\0RRE" + 8; }
+  uint_fast8_t i = 0;
+  do { buf[i] = (char)(ret[i] + spec->case_adjust); } while (ret[++i]);
   return -(int)i;
 }
 
@@ -921,43 +1017,40 @@ static int npf_bin_len(npf_uint_t u) {
 
 static void npf_bufputc(int c, void *ctx) {
   npf_bufputc_ctx_t *bpc = (npf_bufputc_ctx_t *)ctx;
-  if (bpc->cur < bpc->len) { bpc->dst[bpc->cur++] = (char)c; }
+  // NULL dst -> count-only mode (size-query semantics).
+  if (bpc->dst && bpc->len) { --bpc->len; *bpc->dst++ = (char)c; }
 }
 
-static void npf_bufputc_nop(int c, void *ctx) { (void)c; (void)ctx; }
+#define NPF_PUTC(VAL) do { pc((int)(VAL), pc_ctx); ++npf_n; } while (0)
+// Emission inside a conversion: the spec's total length is added to npf_n in bulk.
+#define NPF_PUT(VAL) do { pc((int)(VAL), pc_ctx); } while (0)
 
-typedef struct npf_cnt_putc_ctx {
-  npf_putc pc;
-  void *ctx;
-  int n;
-} npf_cnt_putc_ctx_t;
+#define NPF_EXTRACT(DST, MOD, CAST_TO, EXTRACT_AS) \
+  case NPF_FMT_SPEC_LEN_MOD_##MOD: DST = (CAST_TO)va_arg(args, EXTRACT_AS); break
 
-static void npf_putc_cnt(int c, void *ctx) {
-  npf_cnt_putc_ctx_t *pc_cnt = (npf_cnt_putc_ctx_t *)ctx;
-  ++pc_cnt->n;
-  pc_cnt->pc(c, pc_cnt->ctx); // sibling-call optimization
-}
+// When sizeof(long) == sizeof(int) (any ILP32 ABI, e.g. ARM EABI / Win32 / Win64),
+// va_arg(*args, long) and va_arg(*args, int) read the same bits, so the LONG
+// case can fall into the int-promotion default.
+#if LONG_MAX == INT_MAX
+  #define NPF_LONG_IS_INT 1
+#else
+  #define NPF_LONG_IS_INT 0
+#endif
 
-#define NPF_PUTC(VAL) do { npf_putc_cnt((int)(VAL), &pc_cnt); } while (0)
-
-#define NPF_EXTRACT(MOD, CAST_TO, EXTRACT_AS) \
-  case NPF_FMT_SPEC_LEN_MOD_##MOD: val = (CAST_TO)va_arg(args, EXTRACT_AS); break
 
 #define NPF_WRITEBACK(MOD, TYPE) \
-  case NPF_FMT_SPEC_LEN_MOD_##MOD: *(va_arg(args, TYPE *)) = (TYPE)pc_cnt.n; break
+  case NPF_FMT_SPEC_LEN_MOD_##MOD: *(va_arg(args, TYPE *)) = (TYPE)npf_n; break
 
 int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
   npf_format_spec_t fs;
   char const *cur = format;
-  npf_cnt_putc_ctx_t pc_cnt;
-  pc_cnt.pc = pc;
-  pc_cnt.ctx = pc_ctx;
-  pc_cnt.n = 0;
+  int npf_n = 0;
 
   while (*cur) {
-    int const fs_len = (*cur != '%') ? 0 : npf_parse_format_spec(cur, &fs);
-    if (!fs_len) { NPF_PUTC(*cur++); continue; }
-    cur += fs_len;
+    char const *const fs_end =
+      (*cur != '%') ? 0 : npf_parse_format_spec_end(cur, &fs);
+    if (!fs_end) { NPF_PUTC(*cur++); continue; }
+    cur = fs_end;
 
     // Extract star-args immediately
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
@@ -978,47 +1071,36 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
   // Set default precision (we can do that only now that we have extracted the
-  // argument-provided precision (".*"), and know whether to ignore that or not
-  #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
-    if (fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) {
-      switch (fs.conv_spec) {
-        case NPF_FMT_SPEC_CONV_FLOAT_DEC:
-        case NPF_FMT_SPEC_CONV_FLOAT_SCI:
-        case NPF_FMT_SPEC_CONV_FLOAT_SHORTEST:
-          fs.prec = 6;
-          break;
-#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
-        case NPF_FMT_SPEC_CONV_FLOAT_HEX:
-          fs.prec = (NPF_DOUBLE_MAN_BITS + 3) / 4;
-          break;
-#endif
-        default:
-          break;
-      }
+  // argument-provided precision (".*"), and know whether to ignore that or not.
+  if (fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) {
+    if (fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER) {
+      fs.prec = (sizeof(void *) * CHAR_BIT + 3) / 4;
     }
-  #endif
-
-  if ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) &&
-      (fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER)) {
-        fs.prec = (sizeof(void *) * CHAR_BIT + 3) / 4;
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+    // float specs are last in the enum; a single range check identifies them.
+    else if (fs.conv_spec >= NPF_FMT_SPEC_CONV_FLOAT_DEC) {
+#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
+      fs.prec = (fs.conv_spec == NPF_FMT_SPEC_CONV_FLOAT_HEX)
+        ? (NPF_DOUBLE_MAN_BITS + 3) / 4 : 6;
+#else
+      fs.prec = 6;
+#endif
+    }
+#endif
   }
 #endif
 
 #if (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1) && \
     (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1)
-    // For d i o u x X, the '0' flag must be ignored if a precision is provided
-    if (fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) {
-      switch (fs.conv_spec) {
-        case NPF_FMT_SPEC_CONV_SIGNED_INT:
-        case NPF_FMT_SPEC_CONV_OCTAL:
-        case NPF_FMT_SPEC_CONV_HEX_INT:
-        case NPF_FMT_SPEC_CONV_UNSIGNED_INT:
-          fs.leading_zero_pad = 0;
-          break;
-        default:
-          break;
-      }
-    }
+    // For d i o u x X, the '0' flag must be ignored if a precision is provided.
+    // Those conversions are contiguous in the enum (except BINARY, b).
+    if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) &&
+        (fs.conv_spec >= NPF_FMT_SPEC_CONV_SIGNED_INT) &&
+        (fs.conv_spec <= NPF_FMT_SPEC_CONV_UNSIGNED_INT)
+#if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
+        && (fs.conv_spec != NPF_FMT_SPEC_CONV_BINARY)
+#endif
+       ) { fs.leading_zero_pad = 0; }
 #endif
 
     union { char cbuf_mem[NANOPRINTF_CONVERSION_BUFFER_SIZE]; npf_uint_t binval; } u;
@@ -1037,305 +1119,273 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #endif
 
     // Extract and convert the argument to string, point cbuf at the text.
-    switch (fs.conv_spec) {
-      case NPF_FMT_SPEC_CONV_PERCENT:
-        *cbuf = '%';
-        cbuf_len = 1;
-        break;
-
-      case NPF_FMT_SPEC_CONV_CHAR:
-        *cbuf = (char)va_arg(args, int);
-        cbuf_len = 1;
-        break;
-
-      case NPF_FMT_SPEC_CONV_STRING: {
-        cbuf = va_arg(args, char *);
-#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-        for (char const *s = cbuf;
-             ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec)) && cbuf && *s;
-             ++s, ++cbuf_len);
+    // Range checks for INT and FLOAT families avoid an 11-entry dispatch table.
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+    if (fs.conv_spec >= NPF_FMT_SPEC_CONV_FLOAT_DEC) {
+      npf_real_t val;
+#if NANOPRINTF_USE_FLOAT_SINGLE_PRECISION == 1
+      val = va_arg(args, npf_float_t).val;
+#elif LDBL_MANT_DIG == DBL_MANT_DIG
+      // long double has the same representation as double (e.g. ARM EABI);
+      // no need to branch on the 'L' length modifier.
+      val = va_arg(args, double);
 #else
-        for (char const *s = cbuf; cbuf && *s; ++s, ++cbuf_len); // strlen
+      if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_LONG_DOUBLE) {
+        val = (npf_real_t)va_arg(args, long double);
+      } else {
+        val = va_arg(args, double);
+      }
 #endif
-      } break;
 
-      case NPF_FMT_SPEC_CONV_SIGNED_INT: {
-        npf_int_t val = 0;
-        switch (fs.length_modifier) {
-          NPF_EXTRACT(NONE, int, int);
-#if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
-          NPF_EXTRACT(SHORT, short, int);
-          NPF_EXTRACT(CHAR, signed char, int);
-#endif
-          NPF_EXTRACT(LONG, long, long);
-#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-          NPF_EXTRACT(LARGE_LONG_LONG, long long, long long);
-          NPF_EXTRACT(LARGE_INTMAX, intmax_t, intmax_t);
-          NPF_EXTRACT(LARGE_SIZET, npf_ssize_t, npf_ssize_t);
-          NPF_EXTRACT(LARGE_PTRDIFFT, ptrdiff_t, ptrdiff_t);
-#endif
-          default: break;
-        }
-
-        sign_c = (val < 0) ? '-' : fs.prepend;
-
-#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
+      { npf_real_bin_t const b = npf_real_to_int_rep(val);
+        sign_c = (b >> NPF_REAL_SIGN_POS) ? '-' : fs.prepend;
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-        zero = !val;
+        zero = !(b & ~((npf_real_bin_t)1 << NPF_REAL_SIGN_POS));
 #endif
-        // special case, if prec and value are 0, skip
-        if (!val && (fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec) {
-          cbuf_len = 0;
-        } else
+      }
+#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
+      if ((fs.conv_spec == NPF_FMT_SPEC_CONV_FLOAT_HEX) &&
+          ((cbuf_len = npf_atoa_rev(cbuf, &fs, (double)val)) > 0)) {
+        need_0x = (char)('X' + fs.case_adjust);
+      } else
 #endif
-        {
-          npf_uint_t uval = (npf_uint_t)val;
-          if (val < 0) { uval = 0 - uval; }
-          cbuf_len = npf_utoa_rev(uval, cbuf, 10, fs.case_adjust);
+      { cbuf_len = npf_ftoa_rev(cbuf, &fs, val); }
+      if (cbuf_len < 0) { // negative means text (not number), so ignore the '0' flag
+         cbuf_len = -cbuf_len;
+#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
+         fs.leading_zero_pad = 0;
+#endif
+      }
+    } else
+#endif
+#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
+    if (fs.conv_spec == NPF_FMT_SPEC_CONV_WRITEBACK) {
+      switch (fs.length_modifier) {
+        case NPF_FMT_SPEC_LEN_MOD_NONE: *(va_arg(args, int *)) = npf_n; break;
+#if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
+        case NPF_FMT_SPEC_LEN_MOD_SHORT: *(va_arg(args, short *)) = (short)npf_n; break;
+        case NPF_FMT_SPEC_LEN_MOD_CHAR: *(va_arg(args, signed char *)) = (signed char)npf_n; break;
+#endif
+        case NPF_FMT_SPEC_LEN_MOD_LONG: *(va_arg(args, long *)) = (long)npf_n; break;
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+        case NPF_FMT_SPEC_LEN_MOD_LARGE_LONG_LONG: *(va_arg(args, long long *)) = (long long)npf_n; break;
+        case NPF_FMT_SPEC_LEN_MOD_LARGE_INTMAX: *(va_arg(args, intmax_t *)) = (intmax_t)npf_n; break;
+        case NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET: *(va_arg(args, npf_ssize_t *)) = (npf_ssize_t)npf_n; break;
+        case NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT: *(va_arg(args, ptrdiff_t *)) = (ptrdiff_t)npf_n; break;
+#endif
+        default: break;
+      }
+    } else
+#endif
+    if (fs.conv_spec >= NPF_FMT_SPEC_CONV_SIGNED_INT) {
+      npf_uint_t val;
+      uint_fast8_t base = 10u;
+
+      if (fs.conv_spec == NPF_FMT_SPEC_CONV_SIGNED_INT) {
+        npf_int_t sval = 0;
+        switch (fs.length_modifier) {
+#if !NPF_LONG_IS_INT
+          NPF_EXTRACT(sval, LONG, long, long);
+#endif
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+          NPF_EXTRACT(sval, LARGE_LONG_LONG, long long, long long);
+          NPF_EXTRACT(sval, LARGE_INTMAX, intmax_t, intmax_t);
+          NPF_EXTRACT(sval, LARGE_SIZET, npf_ssize_t, npf_ssize_t);
+          NPF_EXTRACT(sval, LARGE_PTRDIFFT, ptrdiff_t, ptrdiff_t);
+#endif
+          default: {
+            int v = va_arg(args, int);
+#if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
+            if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_SHORT) { v = (short)v; }
+            else if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_CHAR) { v = (signed char)v; }
+#endif
+            sval = v;
+          } break;
         }
-      } break;
-
-#if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
-      case NPF_FMT_SPEC_CONV_BINARY:
-#endif
-      case NPF_FMT_SPEC_CONV_OCTAL:
-      case NPF_FMT_SPEC_CONV_HEX_INT:
-      case NPF_FMT_SPEC_CONV_UNSIGNED_INT:
-      case NPF_FMT_SPEC_CONV_POINTER: {
-        npf_uint_t val = 0;
-
+        sign_c = (sval < 0) ? '-' : fs.prepend;
+        val = (npf_uint_t)sval;
+        if (sval < 0) { val = 0 - val; }
+      } else {
         if (fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER) {
           val = (npf_uint_t)(uintptr_t)va_arg(args, void *);
+          base = 16u;
         } else {
           switch (fs.length_modifier) {
-            NPF_EXTRACT(NONE, unsigned, unsigned);
-#if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
-            NPF_EXTRACT(SHORT, unsigned short, unsigned);
-            NPF_EXTRACT(CHAR, unsigned char, unsigned);
+#if !NPF_LONG_IS_INT
+            NPF_EXTRACT(val, LONG, unsigned long, unsigned long);
 #endif
-            NPF_EXTRACT(LONG, unsigned long, unsigned long);
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-            NPF_EXTRACT(LARGE_LONG_LONG, unsigned long long, unsigned long long);
-            NPF_EXTRACT(LARGE_INTMAX, uintmax_t, uintmax_t);
-            NPF_EXTRACT(LARGE_SIZET, size_t, size_t);
-            NPF_EXTRACT(LARGE_PTRDIFFT, npf_uptrdiff_t, npf_uptrdiff_t);
+            NPF_EXTRACT(val, LARGE_LONG_LONG, unsigned long long, unsigned long long);
+            NPF_EXTRACT(val, LARGE_INTMAX, uintmax_t, uintmax_t);
+            NPF_EXTRACT(val, LARGE_SIZET, size_t, size_t);
+            NPF_EXTRACT(val, LARGE_PTRDIFFT, npf_uptrdiff_t, npf_uptrdiff_t);
 #endif
-            default: break;
+            default: {
+              unsigned v = va_arg(args, unsigned);
+#if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
+              if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_SHORT) { v = (unsigned short)v; }
+              else if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_CHAR) { v = (unsigned char)v; }
+#endif
+              val = v;
+            } break;
           }
+          if (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) { base = 8u; }
+          else if (fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) { base = 16u; }
         }
+      }
 
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-        zero = !val;
+      zero = !val;
 #endif
-        if (!val && (fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec) {
-          // Zero value and explicitly-requested zero precision means "print nothing".
+      if (!val && (fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec) {
+        // cbuf_len was initialized to 0; preserved here.
 #if NANOPRINTF_USE_ALT_FORM_FLAG == 1
-          if ((fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) && fs.alt_form) {
-            fs.prec = 1; // octal special case, print a single '0'
-          }
+        if (base == 8u && fs.alt_form) { fs.prec = 1; } // octal '#' special
 #endif
-        } else
+      } else
 #endif
+      {
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
         if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) {
           cbuf_len = npf_bin_len(val); u.binval = val;
         } else
 #endif
-        {
-          uint_fast8_t const base = (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) ?
-            8u : ((fs.conv_spec == NPF_FMT_SPEC_CONV_UNSIGNED_INT) ? 10u : 16u);
-          cbuf_len = npf_utoa_rev(val, cbuf, base, fs.case_adjust);
-        }
+        { cbuf_len = npf_utoa_rev(val, cbuf, base, fs.case_adjust); }
 
 #if NANOPRINTF_USE_ALT_FORM_FLAG == 1
-        if (val && fs.alt_form && (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL)) {
-          cbuf[cbuf_len++] = '0'; // OK to add leading octal '0' immediately.
-        }
-
-        if (val && fs.alt_form) { // 0x or 0b but can't write it yet.
-          if ((fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) ||
-              (fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER)) { need_0x = 'X'; }
+        if (val && fs.alt_form) {
+          if (base == 8u) {
+            cbuf[cbuf_len++] = '0';
+          } else if (base == 16u) {
+            need_0x = (char)('X' + fs.case_adjust);
+          }
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
-          else if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) { need_0x = 'B'; }
+          else if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) {
+            need_0x = (char)('B' + fs.case_adjust);
+          }
 #endif
-          if (need_0x) { need_0x = (char)(need_0x + fs.case_adjust); }
         }
 #endif
-      } break;
-
-#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
-      case NPF_FMT_SPEC_CONV_WRITEBACK:
-        switch (fs.length_modifier) {
-          NPF_WRITEBACK(NONE, int);
-#if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
-          NPF_WRITEBACK(SHORT, short);
-          NPF_WRITEBACK(CHAR, signed char);
-#endif
-          NPF_WRITEBACK(LONG, long);
-#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-          NPF_WRITEBACK(LARGE_LONG_LONG, long long);
-          NPF_WRITEBACK(LARGE_INTMAX, intmax_t);
-          NPF_WRITEBACK(LARGE_SIZET, npf_ssize_t);
-          NPF_WRITEBACK(LARGE_PTRDIFFT, ptrdiff_t);
-#endif
-          default: break;
-        } break;
-#endif
-
-#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
-      case NPF_FMT_SPEC_CONV_FLOAT_DEC:
-      case NPF_FMT_SPEC_CONV_FLOAT_SCI:
-      case NPF_FMT_SPEC_CONV_FLOAT_SHORTEST:
-#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
-      case NPF_FMT_SPEC_CONV_FLOAT_HEX:
-#endif
-      {
-        npf_real_t val;
-#if NANOPRINTF_USE_FLOAT_SINGLE_PRECISION == 1
-        val = va_arg(args, npf_float_t).val;
+      }
+    } else if (fs.conv_spec == NPF_FMT_SPEC_CONV_STRING) {
+      cbuf = va_arg(args, char *);
+#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
+      for (char const *s = cbuf;
+           ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec)) && cbuf && *s;
+           ++s, ++cbuf_len);
 #else
-        if (fs.length_modifier == NPF_FMT_SPEC_LEN_MOD_LONG_DOUBLE) {
-          val = (npf_real_t)va_arg(args, long double);
-        } else {
-          val = va_arg(args, double);
-        }
+      for (char const *s = cbuf; cbuf && *s; ++s, ++cbuf_len); // strlen
 #endif
-
-        { npf_real_bin_t const b = npf_real_to_int_rep(val);
-          sign_c = (b >> NPF_REAL_SIGN_POS) ? '-' : fs.prepend;
-#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-          zero = !(b & ~((npf_real_bin_t)1 << NPF_REAL_SIGN_POS));
-#endif
-        }
-#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
-        if ((fs.conv_spec == NPF_FMT_SPEC_CONV_FLOAT_HEX) &&
-            ((cbuf_len = npf_atoa_rev(cbuf, &fs, (double)val)) > 0)) {
-          need_0x = (char)('X' + fs.case_adjust);
-        } else
-#endif
-        { cbuf_len = npf_ftoa_rev(cbuf, &fs, val); }
-        if (cbuf_len < 0) { // negative means text (not number), so ignore the '0' flag
-           cbuf_len = -cbuf_len;
-#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-           fs.leading_zero_pad = 0;
-#endif
-        }
-      } break;
-#endif
-      default: break;
+    } else {
+      // PERCENT or CHAR: produce a 1-char buffer.
+      *cbuf = (fs.conv_spec == NPF_FMT_SPEC_CONV_CHAR) ? (char)va_arg(args, int) : '%';
+      cbuf_len = 1;
     }
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-    // Compute the field width pad character
-    if (fs.field_width_opt != NPF_FMT_SPEC_OPT_NONE) {
-      // The '0' flag is only legal with numeric types, and '-' overrides '0'.
-      if (fs.leading_zero_pad && !fs.left_justified) {
+    // Compute the field width pad character. '0' flag only with numeric types,
+    // '-' overrides '0', and a blank result (prec.0 with zero value) suppresses '0'.
+    // With no field width, field_pad clamps to 0 below, so pad_c is never used.
+    pad_c = ' ';
+    if (fs.leading_zero_pad && !fs.left_justified
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-        if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero) {
-          pad_c = ' ';
-        } else
+        && !((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero)
 #endif
-        { pad_c = '0'; }
-      } else { pad_c = ' '; }
-    }
+       ) { pad_c = '0'; }
 #endif
 
-    // Compute the number of bytes to truncate or '0'-pad.
+    // Compute the number of bytes to truncate or '0'-pad. Skip for STRING
+    // (already handled by precision-limited length) and FLOAT (precision is
+    // after the decimal point; float specs are last in the enum).
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-    if (fs.conv_spec != NPF_FMT_SPEC_CONV_STRING) {
+    if ((fs.conv_spec != NPF_FMT_SPEC_CONV_STRING)
 #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
-      // float precision is after the decimal point
-      if ((fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_DEC) &&
-          (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SCI) &&
-          (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SHORTEST)
-#if NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER == 1
-          && (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_HEX)
+        && (fs.conv_spec < NPF_FMT_SPEC_CONV_FLOAT_DEC)
 #endif
-      )
+       ) { prec_pad = NPF_MAX(0, fs.prec - cbuf_len); }
 #endif
-      { prec_pad = NPF_MAX(0, fs.prec - cbuf_len); }
-    }
+
+    // Total bytes this conversion emits; npf_n is bulk-updated at the end.
+    int spec_len = cbuf_len + !!sign_c + (need_0x ? 2 : 0)
+#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
+                   + prec_pad
 #endif
+                   ;
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
     // Given the full converted length, how many pad bytes?
-    field_pad = fs.field_width - cbuf_len - !!sign_c;
-    if (need_0x) { field_pad -= 2; }
-#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-    field_pad -= prec_pad;
-#endif
-    field_pad = NPF_MAX(0, field_pad);
+    field_pad = fs.field_width - spec_len;
+    if (field_pad < 0) { field_pad = 0; }
+    spec_len += field_pad;
 
-    // Apply right-justified field width if requested
-    if (!fs.left_justified && pad_c) { // If leading zeros pad, sign goes first.
-      if (pad_c == '0') {
-        if (sign_c) { NPF_PUTC(sign_c); sign_c = 0; }
-        // Pad byte is '0', write '0x' before '0' pad chars.
-        if (need_0x) { NPF_PUTC('0'); NPF_PUTC(need_0x); }
-      }
-      while (field_pad-- > 0) { NPF_PUTC(pad_c); }
-      // Pad byte is ' ', write '0x' after ' ' pad chars but before number.
-      if ((pad_c != '0') && need_0x) {
-        if (sign_c) { NPF_PUTC(sign_c); sign_c = 0; }
-        NPF_PUTC('0'); NPF_PUTC(need_0x);
-      }
-    } else
-#endif
-    { // no pad, '0x' requested.
-      if (need_0x) {
-        if (sign_c) { NPF_PUTC(sign_c); sign_c = 0; }
-        NPF_PUTC('0'); NPF_PUTC(need_0x);
-      }
+    // Right-justified padding: zero-pad goes AFTER sign/0x; space-pad goes BEFORE.
+#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
+    // '0'-padding is contiguous with the leading precision zeros, so fold it into
+    // prec_pad; sign/0x is then emitted exactly once below. prec_pad stays 0 for
+    // STRING unless folded into, so the hoisted loop is a no-op there.
+    if (pad_c == '0') {
+      prec_pad += field_pad;
+      field_pad = 0;
     }
-
-    // Write the converted payload
-    if (fs.conv_spec == NPF_FMT_SPEC_CONV_STRING) {
-      for (int i = 0; cbuf && (i < cbuf_len); ++i) { NPF_PUTC(cbuf[i]); }
-    } else {
-      if (sign_c) { NPF_PUTC(sign_c); }
-#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-      while (prec_pad-- > 0) { NPF_PUTC('0'); } // int precision leads.
+#else
+    if (pad_c == '0') {
+      if (sign_c) { NPF_PUT(sign_c); sign_c = 0; }
+      if (need_0x) { NPF_PUT('0'); NPF_PUT(need_0x); need_0x = 0; }
+    }
 #endif
+    if (!fs.left_justified) {
+      while (field_pad-- > 0) { NPF_PUT(pad_c); }
+    }
+#endif
+    if (sign_c) { NPF_PUT(sign_c); }
+    if (need_0x) { NPF_PUT('0'); NPF_PUT(need_0x); }
+#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
+    while (prec_pad-- > 0) { NPF_PUT('0'); } // leading zeros: precision and '0' pad
+#endif
+
+    // Write the converted payload. The STRING parse loop guarantees cbuf_len == 0
+    // when cbuf is NULL, so the output loop can elide the `cbuf &&` check.
+    if (fs.conv_spec == NPF_FMT_SPEC_CONV_STRING) {
+      for (int i = 0; i < cbuf_len; ++i) { NPF_PUT(cbuf[i]); }
+    } else {
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
       if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) {
-        while (cbuf_len) { NPF_PUTC('0' + ((u.binval >> --cbuf_len) & 1)); }
+        while (cbuf_len) { NPF_PUT('0' + ((u.binval >> --cbuf_len) & 1)); }
       } else
 #endif
-      { while (cbuf_len-- > 0) { NPF_PUTC(cbuf[cbuf_len]); } } // payload is reversed
+      { while (cbuf_len-- > 0) { NPF_PUT(cbuf[cbuf_len]); } } // payload is reversed
     }
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-    if (fs.left_justified && pad_c) { // Apply left-justified field width
-      while (field_pad-- > 0) { NPF_PUTC(pad_c); }
-    }
+    // Apply left-justified field width. The right-justified loop above has
+    // already run field_pad below zero in the non-left-justified case, so
+    // this loop body only executes for left-justified specifiers.
+    while (field_pad-- > 0) { NPF_PUT(pad_c); }
 #endif
+    npf_n += spec_len;
   }
 
-  return pc_cnt.n;
+  return npf_n;
 }
 
 #undef NPF_PUTC
+#undef NPF_PUT
 #undef NPF_EXTRACT
-#undef NPF_WRITEBACK
 
 int npf_vsnprintf(char * NPF_RESTRICT buffer,
                   size_t bufsz,
                   char const * NPF_RESTRICT format,
                   va_list vlist) {
-  npf_bufputc_ctx_t bufputc_ctx;
-  bufputc_ctx.dst = buffer;
-  bufputc_ctx.len = bufsz;
-  bufputc_ctx.cur = 0;
-
-  npf_putc const pc = buffer ? npf_bufputc : npf_bufputc_nop;
-  int const n = npf_vpprintf(pc, &bufputc_ctx, format, vlist);
+  npf_bufputc_ctx_t bufputc_ctx = { buffer, bufsz };
+  int const n = npf_vpprintf(npf_bufputc, &bufputc_ctx, format, vlist);
 
   if (buffer && bufsz) {
+    // npf_vpprintf never returns negative (no encoding errors possible).
 #ifdef NANOPRINTF_SNPRINTF_SAFE_EMPTY_STRING_ON_OVERFLOW
-    buffer[(n < 0 || (unsigned)n >= bufsz) ? 0 : n] = '\0';
+    buffer[(unsigned)n >= bufsz ? 0 : (unsigned)n] = '\0';
 #else
-    buffer[n < 0 ? 0 : NPF_MIN((unsigned)n, bufsz - 1)] = '\0';
+    buffer[NPF_MIN((unsigned)n, bufsz - 1)] = '\0';
 #endif
   }
 

--- a/tests/gen_tests.py
+++ b/tests/gen_tests.py
@@ -1,7 +1,7 @@
 """Generate the conformance test build artifacts for nanoprintf.
 
-Enumerates all valid flag combinations (192), then for each generates
-both a C and C++ compilation, for a total of 384 test objects:
+Enumerates all valid flag combinations (768), then for each generates
+both a C and C++ compilation, for a total of 1536 test objects:
   - main.c                : declares + calls all per-combo test functions
   - Makefile               : POSIX make rules (cc + c++)
   - compile_commands.json  : Windows parallel builds (cl.exe)
@@ -34,6 +34,7 @@ FLAGS = [
     "NANOPRINTF_USE_ALT_FORM_FLAG",
     "NANOPRINTF_USE_FLOAT_SINGLE_PRECISION",
     "NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER",
+    "NANOPRINTF_USE_DIVISION_FREE_CONVERSION",
 ]
 
 
@@ -80,6 +81,7 @@ def combo_label(combo: dict[str, int], lang: str) -> str:
         "NANOPRINTF_USE_ALT_FORM_FLAG": "alt",
         "NANOPRINTF_USE_FLOAT_SINGLE_PRECISION": "sp",
         "NANOPRINTF_USE_FLOAT_HEX_FORMAT_SPECIFIER": "hexa",
+        "NANOPRINTF_USE_DIVISION_FREE_CONVERSION": "divfree",
     }
     parts = [f"{short[k]}={v}" for k, v in combo.items()]
     return f"[{lang}] " + " ".join(parts)

--- a/tests/unit_bufputc.cc
+++ b/tests/unit_bufputc.cc
@@ -5,31 +5,36 @@
 TEST_CASE("npf_bufputc") {
   npf_bufputc_ctx_t bpc;
   char buf[32];
-  bpc.cur = 0;
   bpc.len = sizeof(buf);
   bpc.dst = buf;
 
   SUBCASE("Writes start at beginning of buffer") {
     npf_bufputc('A', &bpc);
-    REQUIRE(bpc.dst[0] == 'A');
+    REQUIRE(buf[0] == 'A');
   }
 
-  SUBCASE("Increments cur after write") {
+  SUBCASE("Advances dst after write") {
     npf_bufputc('A', &bpc);
-    REQUIRE(bpc.cur == 1);
+    REQUIRE(bpc.dst == buf + 1);
+  }
+
+  SUBCASE("Decrements len after write") {
+    npf_bufputc('A', &bpc);
+    REQUIRE(bpc.len == sizeof(buf) - 1);
   }
 
   SUBCASE("Writes to final byte of buffer") {
     buf[sizeof(buf) - 1] = '*';
-    bpc.cur = bpc.len - 1;
+    bpc.dst = &buf[sizeof(buf) - 1];
+    bpc.len = 1;
     npf_bufputc('A', &bpc);
     REQUIRE(buf[sizeof(buf) - 1] == 'A');
   }
 
   SUBCASE("Doesn't write past final byte of buffer") {
     buf[3] = '*';
-    bpc.len = 3;
-    bpc.cur = 3;
+    bpc.dst = &buf[3];
+    bpc.len = 0;
     npf_bufputc('A', &bpc);
     REQUIRE(buf[3] == '*');
   }
@@ -41,8 +46,8 @@ TEST_CASE("npf_bufputc") {
     npf_bufputc('D', &bpc);
     npf_bufputc('E', &bpc);
     npf_bufputc('F', &bpc);
-    REQUIRE(bpc.cur == 6);
-    bpc.dst[6] = '\0';
-    REQUIRE(std::string(bpc.dst) == "ABCDEF");
+    REQUIRE(bpc.dst == buf + 6);
+    buf[6] = '\0';
+    REQUIRE(std::string(buf) == "ABCDEF");
   }
 }

--- a/tests/unit_utoa_rev_divfree.cc
+++ b/tests/unit_utoa_rev_divfree.cc
@@ -1,0 +1,114 @@
+#define NANOPRINTF_USE_DIVISION_FREE_CONVERSION 1
+#include "unit_nanoprintf.h"
+
+#include <climits>
+#include <cstdint>
+#include <string>
+
+static void require_divfree_utoa(
+    std::string const &expected,
+    npf_uint_t val,
+    uint_fast8_t base,
+    char case_adj = 'a' - 'A') {
+  char buf[64];
+  int const n = npf_utoa_rev(val, buf, base, case_adj);
+  buf[n] = '\0';
+  REQUIRE(n == (int)expected.size());
+  REQUIRE(std::string{buf} == expected);
+}
+
+// First n in [lo, hi] (stepping by step) where npf_div10(n) != n / 10, or -1
+// if the whole range is exact.
+static int64_t first_div10_mismatch(uint64_t lo, uint64_t hi, uint64_t step) {
+  for (uint64_t n = lo; n <= hi; n += step) {
+    if (npf_div10((uint32_t)n) != (uint32_t)(n / 10u)) { return (int64_t)n; }
+  }
+  return -1;
+}
+
+TEST_CASE("npf_div10 is exact") {
+  SUBCASE("exhaustive low range") {
+    REQUIRE(first_div10_mismatch(0, 2000000, 1) == -1);
+  }
+
+  SUBCASE("power-of-ten boundaries") {
+    for (uint64_t p = 10; p <= 1000000000u; p *= 10) {
+      REQUIRE(first_div10_mismatch(p - 2, p + 2, 1) == -1);
+    }
+  }
+
+  SUBCASE("power-of-two boundaries") {
+    for (int k = 1; k < 32; ++k) {
+      uint64_t const p = (uint64_t)1 << k;
+      REQUIRE(first_div10_mismatch(p - 2, p + 2, 1) == -1);
+    }
+  }
+
+  SUBCASE("top of range") {
+    REQUIRE(first_div10_mismatch(0xFFFFF000u, 0xFFFFFFFFu, 1) == -1);
+  }
+
+  SUBCASE("strided full sweep") {
+    REQUIRE(first_div10_mismatch(0, 0xFFFFFFFFu, 65521) == -1); // prime stride
+  }
+}
+
+TEST_CASE("npf_utoa_rev division-free") {
+  SUBCASE("base 10") {
+    require_divfree_utoa("0", 0, 10);
+    require_divfree_utoa("9", 9, 10);
+    require_divfree_utoa("01", 10, 10);
+    require_divfree_utoa("99", 99, 10);
+    require_divfree_utoa("001", 100, 10);
+    require_divfree_utoa("54321", 12345, 10);
+    require_divfree_utoa("000001", 100000, 10);
+  }
+
+  SUBCASE("base 10 maxima") {
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+#if UINTMAX_MAX == 18446744073709551615u
+    require_divfree_utoa("51615590737044764481", UINTMAX_MAX, 10);
+#else
+#error Unknown UINTMAX_MAX here, please add another branch.
+#endif
+#else
+#if UINT_MAX == 4294967295
+    require_divfree_utoa("5927694924", UINT_MAX, 10);
+#else
+#error Unknown UINT_MAX here, please add another branch.
+#endif
+#endif
+  }
+
+  SUBCASE("base 8") {
+    require_divfree_utoa("0", 0, 8);
+    require_divfree_utoa("7", 7, 8);
+    require_divfree_utoa("01", 010, 8);
+    require_divfree_utoa("7654321", 01234567, 8);
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+#if UINTMAX_MAX == 18446744073709551615u
+    require_divfree_utoa("7777777777777777777771", UINTMAX_MAX, 8);
+#endif
+#else
+#if UINT_MAX == 4294967295
+    require_divfree_utoa("77777777773", UINT_MAX, 8);
+#endif
+#endif
+  }
+
+  SUBCASE("base 16") {
+    require_divfree_utoa("0", 0, 16);
+    require_divfree_utoa("f", 0xf, 16);
+    require_divfree_utoa("4d3c2b1a", 0xa1b2c3d4, 16);
+    require_divfree_utoa("FEDCBA98", 0x89abcdef, 16, 0);
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+#if UINTMAX_MAX == 18446744073709551615u
+    require_divfree_utoa("ffffffffffffffff", UINTMAX_MAX, 16);
+#endif
+#else
+#if UINT_MAX == 4294967295
+    require_divfree_utoa("ffffffff", UINT_MAX, 16);
+#endif
+#endif
+  }
+}


### PR DESCRIPTION
**FC Notes:**
This returns around a 15 to 20 % reduction in size (Os/O2/O3 tested across a few compilers gcc13/15/clang21). 
Passes all conformance tests and was also ran against qemu platforms as well (arm m0/m4, risc-v, aarch64, ppc, and mips). 
Target was for a cortex bootloader that I reaaaaaaaaaly needed to get the size below 2k with all the bells and whistles on, it just happened to work across all archs I tested too :).
Please let me know if you have any questions or issues with any of the changes therein.

---
### Test results including new div free mode (x86 machine g++ 13.1.0):
```
  # ── Conformance suite: 384 flag combos × {C, C++} = 768 combos ──────────────

  # Default mode (division-free OFF)
  $ python3 _sizetest/gen_conformance_gcc.py
  $ ( cd tests/generated && mingw32-make -j12 )
  PASSED: 433760 assertions across 768 combos (384 flags x 2 langs)

  # Division-free mode (NANOPRINTF_USE_DIVISION_FREE_CONVERSION=1)
  $ python3 _sizetest/gen_conformance_gcc.py \
        --extra-cflags="-DNANOPRINTF_USE_DIVISION_FREE_CONVERSION=1"
  $ ( cd tests/generated && mingw32-make clean && mingw32-make -j12 )
  PASSED: 433760 assertions across 768 combos (384 flags x 2 langs)

  # ── Unit tests (doctest), LARGE=0 and LARGE=1 ──────────────────────────────

  # Default mode
  $ bash _sizetest/check_tests_gcc.sh
  [doctest] assertions: 932 | 932 passed | 0 failed |
  [doctest] assertions: 956 | 956 passed | 0 failed |

  # Division-free mode
  $ EXTRA_DEFS=-DNANOPRINTF_USE_DIVISION_FREE_CONVERSION=1 bash _sizetest/check_tests_gcc.sh
  [doctest] assertions: 932 | 932 passed | 0 failed |
  [doctest] assertions: 956 | 956 passed | 0 failed |

```
---
### Size results:
Configurations ran:
```
  - default_explicit: stock default config.
  - nofw: default minus FIELD_WIDTH.
  - nosmall: default minus SMALL length modifiers
  - noalt: default minus the ALT_FORM.
  - single: default but FLOAT_SINGLE_PRECISION.
  - lean: float-only minimum, just PRECISION + FLOAT
  - full: everything on (FIELD_WIDTH, PRECISION, FLOAT, LARGE, SMALL, BINARY, WRITEBACK, ALT_FORM, FLOAT_HEX), dp floats.
```
Results on a cortex m4 (gcc 15.2):
| Config           | m0 linked              | m4 linked              | 
|------------------|------------------------|------------------------|
| default_explicit | 2799 -> 1827 (−972)     | 2531 -> 1755 (−776)     |
| nofw             | 2131 -> 1507 (−624)     | 1959 -> 1483 (−476)     |
| nosmall          | 2751 -> 1771 (−980)     | 2423 -> 1687 (−736)     |
| noalt            | 2515 -> 1687 (−828)     | 2295 -> 1643 (−652)     | 
| single           | 2991 -> 2031 (−960)     | 2639 -> 1875 (−764)     |
| lean             | 2107 -> 1579 (−528)     | 1735 -> 1359 (−376)     | 
| full             | 4207 -> 2951 (−1256)    | 4187 -> 2687 (−1500)    | 
---
### Detailed changes:

1. Add division free conversion flag NANOPRINTF_USE_DIVISION_FREE_CONVERSAION to elimiate divsion calls for very slow micros without a mul/div block (m0).

2. Add NPF_UINT_IS_WIDE which tells the code path if the unsigned type is > 32 bits so we can take a fast path if its < 32

3. Move to using an end-pointer instead of tracking length, this frees us up to just track the returned cursor

4. Change the flags loop to use a for(;;) loop with a ++ on the switch pointer so we can force the \0 to hit the default case.

5. Combine the old >= <= digital test to a sub '0' then < 10 which saves a compare operations.

6. Refactor the conversion specifier to use a lookup table. This lets us remove parts of the lookup table with ifdefs. The benefit is by using a static table we can just handle most operations in one pass by doing the indexing off of the char type [see the (c | 32) = 'a') logic]

7. Change the utaoa_rev to return the end pointer, removed need for local counter, added npof_utoa_rev facace to give methods way to get length and keep bward compat. This saves some register spills.

8. Per .1 for integer to ASCII conversions if we dont have a divison unit and the ...DIV_FREE_CONVERSION flag is on handle the divison with multiples and shifts. Extended to work with 64 bit values as well.

9. For .1/.8 updated npf_div10 to work with just bitshifts/adds which saves space on units with no div.

10. Create handler macros (npr_bin_shr/ npf_bin_shl) for really restricted micros like cortex M0 to do single bit shifts. This is only when they're larger than 64 bit terms, on all other archs this is a normal >> <<.

11. Pack NaN InF into a single if check and return string that we just offset into.

12. Move the IEEE carry bit computation to an unconditional computation and merged the base scaling into a single expression to save a branch operation and some math.

13. For the scaling loop on division free configs handled the man_i /= 5 similar to .8 by moving to a mathamatial identify of (2*N/10 + n%10 >= 5) which lets us use the fast div10 path without having to pull in the software divider on limited platforms.

14. Change integer parth check to be a simple capacity check (end > BUIFFER_SIZE -10) since on a single point arch (32 bit) the amount of digits should be <= 10. For dual float/wide builds we keep the older path for true double conformance.

15. Clean up rounding loop to just read in the buff to a local value then check against a series of if/else terms. Similarly for the error and bail path we use a packed literal and a for loop to handle that more efficently.

16. Refactor formatter to move to a local npf_n and two macros (PUTC and PUT) which let me move the counter into a smaller loop

17. Refactor dispach to use range checks vs the old switch. This ended up being cheaper after a lot of testing to group it correctly than the old switch/jump table.

18. Change the base value calculation to happen where we call the % argument to set it to 16,10,8, etc.

19. Remove need for a switch case in NPF_EXRACT by allowing the L/UL case fall thru on targets where long is int.

20. Collapsed the default precision and '0' flag checks into enum range checks. The indexes are in order in the enums so we can just check the end for the float type or precision for d i o u etc.

21. Combined the places where we were calculating the sign, 0x hex val, and zero pad values into a single path where we calculate the pad width, fold in the zero padding/0x padding, and then check the guards for the left/right padding in one go. This lets me remove a bunch of extra checks across branches and simplifies the logic.

22. Since the string length pass aready has the len checked for  0 when the ptr is null we can remove the && cbuf check.

23. Removed cur field from npf_butfputc_ctx_t, moved to having dst be the cursor and len being the capacity that counts down.

24. Refactorted npf_butputc to remove need for bufputc_nop by moving to an if check for the dst and len being valid. A  null dst now means we're only trying to count.

25. Cleaned up logic in npf_vsnprintf to use a multi-init for the buffer and size. This was enabled since .24 lets us have a count only mechanism.