### PR TITLE
Fix windows CI path to work with the latest windows git contianer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,8 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars${{ matrix.architecture }}.bat"
+          for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -property installationPath`) do set "VSPATH=%%i"
+          call "%VSPATH%\VC\Auxiliary\Build\vcvars${{ matrix.architecture }}.bat"
           python.exe build.py --cfg ${{ matrix.configuration }} -v --arch ${{ matrix.architecture }}
 
   size-reports:

--- a/build.py
+++ b/build.py
@@ -154,6 +154,7 @@ def _build_unit_tests(args: argparse.Namespace) -> bool:
         "/wd5039",
         "/wd5262",
         "/wd5264",
+        "/wd5285",
     ]
 
     # Compile doctest_main.cc once


### PR DESCRIPTION
Git updated and the container for the windows builds no longer works. 
Simple 1 liner to locate MSVC via vswhere instead of  via the old hardcoded VS 2022 Enterprise path.
Old builds were using Image: windows-2022 but the latest image now has Image: windows-2025-vs2026 so the vs is on a different path.