### PR TITLE
CI: bump GitHub Actions to latest (checkout v7, setup-python v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Pyright
         run: python -m pyright --warnings --pythonversion 3.13 build.py tests/gen_tests.py tests/size_report.py
       - name: Ruff
@@ -45,7 +45,7 @@ jobs:
         architecture: [32, 64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build
         env:
           CC: /usr/bin/clang
@@ -78,7 +78,7 @@ jobs:
           architecture: 32
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build
         env:
           CC: ${{ matrix.cc }}
@@ -107,7 +107,7 @@ jobs:
           cxx: clang++
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build
         env:
           CC: ${{ matrix.cc }}
@@ -122,7 +122,7 @@ jobs:
         configuration: [Debug, Release]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build
         run: make -j$(sysctl -n hw.ncpu) CFG=${{ matrix.configuration }} VERBOSE=1
 
@@ -135,9 +135,9 @@ jobs:
         architecture: [32, 64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Build
@@ -157,7 +157,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: AVR2
         shell: bash
@@ -192,7 +192,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Bumps the only two third-party actions to their latest majors to clear the Node.js runtime deprecation warnings (checkout v4 / setup-python v5 run on Node 20; the new majors run on Node 24).

- `actions/checkout@v4` → `@v7` (×8)
- `actions/setup-python@v5` → `@v6`

## Compatibility
- **checkout v5/v6/v7**: Node 24 runtime + a credential-persistence tweak. v7's only behavioral breaking change ("block checking out fork PR for `pull_request_target`/`workflow_run`") does not apply — this workflow triggers only on `pull_request`, tag `push`, `schedule`, and `workflow_dispatch`. The one `fetch-depth: 0` checkout (release job) is unaffected.
- **setup-python v6**: Node 24 runtime bump; `python-version: '3.x'` resolution unchanged.
- Node 24 needs runner ≥ v2.327.1 (GitHub-hosted runners are well past it) and glibc ≥ 2.28 inside the `ghcr.io/charlesnicholson/docker-image` container — already satisfied, since the current actions run Node 20 (same glibc baseline) in that container today.

YAML validated; diff is version-strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)