### PR TITLE
Fix npf_bin_len clz builtin selection on LLP64 targets

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -1018,7 +1018,7 @@ static int npf_bin_len(npf_uint_t u) {
   #endif
 #elif NPF_CLANG || NPF_GCC_PAST_4_6
   #define NPF_HAVE_BUILTIN_CLZ
-  #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+  #if NPF_UINT_IS_WIDE
     #define NPF_CLZ(X) ((sizeof(long long) * CHAR_BIT) - (size_t)__builtin_clzll(X))
   #else
     #define NPF_CLZ(X) ((sizeof(long) * CHAR_BIT) - (size_t)__builtin_clzl(X))


### PR DESCRIPTION
## Bug

In `npf_bin_len()`'s GCC/Clang branch, the choice between `__builtin_clzl` and `__builtin_clzll` is gated on `NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1`, but that flag is orthogonal to `npf_uint_t`'s actual width.

On LLP64 targets (e.g. MinGW-w64 or Clang targeting Windows x64), `long` stays 4 bytes even in 64-bit mode. With `NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 0` (the default), `npf_uint_t` resolves to `uintptr_t`, which is 8 bytes there — but the clz branch still picks `__builtin_clzl`, which expects a 4-byte `unsigned long`. That mismatch trips `-Wconversion` under `-Werror`:

```
nanoprintf.h:1026:23: error: conversion from 'npf_uint_t' {aka 'long long unsigned int'} to 'long unsigned int' may change value [-Werror=conversion]
```

Reproduced with the project's own warning flags (`-pedantic -Wall -Wextra -Wundef -Werror -Wconversion -Wshadow -Wfloat-equal -Wsign-conversion -Wswitch-enum -Wswitch-default`) using MinGW-w64 GCC 8.1.0 x86_64 targeting Windows (a real LLP64 host), with `NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=1` and `NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=0` (default).

Note this doesn't currently affect real-world runtime output — under `NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 0`, every length-modifier path that could hand `npf_bin_len` a value wider than 32 bits is already gated behind `!NPF_LONG_IS_INT`, and `NPF_LONG_IS_INT == 1` on LLP64 — so it's a strict build-time regression (breaks `-Werror` builds), not a computation bug today.

## Fix

Branch on `NPF_UINT_IS_WIDE` instead — the macro already defined right next to `npf_uint_t`'s own typedef specifically to describe whether it's actually wider than 32 bits on the current data model (LP64/LLP64/ILP32), rather than the `LARGE_FORMAT_SPECIFIERS` feature toggle. This mirrors the adjacent MSVC branch just above it, which already selects `_BitScanReverse` vs `_BitScanReverse64` by real pointer width (`_M_X64`) rather than the `LARGE` flag — so the GCC/Clang branch now follows the same correct pattern.

One-line change, no behavior change for any currently-passing configuration.

## Verification

Compiled `nanoprintf.h` with the project's exact `Makefile` warning flags across:
- Default config (`LARGE=0`), native 64-bit LLP64 (MinGW-w64 GCC 8.1.0 x86_64-w64-mingw32) — was failing with the exact error above; clean (0 warnings) after the fix.
- `-m32` (ILP32) — clean before and after (unaffected either way).
- `LARGE=1` (64-bit) — clean before and after (unaffected either way).

Functional regression check of `%b` against 0, 1, 2, 5, 0xFF, 0x80000000, 0xFFFFFFFF — all outputs match expected binary strings after the fix, confirming no behavioral change.