### PR TITLE
Disable ruff CPY001 missing-copyright-notice check

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -9,6 +9,7 @@ ignore = [
   "G004",   # logging-f-string (we don't want multiple string formatters)
   "COM812", # missing-trailing-comma (it's never obvious where to put them)
   "INP001", # implicit-namespace-package (standalone scripts, not a package)
+  "CPY001", # missing-copyright-notice (see LICENSE)
 
   ####### these feel too hostile / opinionated
   "ANN", # flake8-annotations (requires 100% strong typing)


### PR DESCRIPTION
A ruff upgrade enabled `CPY001` (missing-copyright-notice), which flagged `build.py`, `tests/gen_tests.py`, and `tests/size_report.py`. This repo ships a top-level `LICENSE` file, so per-file copyright headers would only add noise. Added `CPY001` to the ignore list in `ruff.toml`; `ruff check .` passes clean again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)