### PR TITLE
Discard the digits of an ignored negative precision

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -1541,7 +1541,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
     if (fs.prec_opt == NPF_FMT_SPEC_OPT_STAR) {
       fs.prec = va_arg(args, int);
-      if (fs.prec < 0) { fs.prec = 0; fs.prec_opt = NPF_FMT_SPEC_OPT_NONE; }
+      if (fs.prec < 0) { fs.prec_opt = NPF_FMT_SPEC_OPT_NONE; }
     }
 #endif
 
@@ -1549,6 +1549,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
   // Set default precision (we can do that only now that we have extracted the
   // argument-provided precision (".*"), and know whether to ignore that or not.
   if (fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) {
+    fs.prec = 0; // a discarded precision ("%.-3d", negative ".*") must not leak
     if (fs.conv_spec == NPF_FMT_SPEC_CONV_POINTER) {
       fs.prec = (sizeof(void *) * CHAR_BIT + 3) / 4;
     }

--- a/tests/conformance.c
+++ b/tests/conformance.c
@@ -1148,11 +1148,29 @@ int NPF_TEST_FUNC(void) {
     NPF_TEST("0", "%.*d", -1, 0);
     NPF_TEST("hello", "%.*s", -1, "hello");
     NPF_TEST("hello world", "%.*s", -1, "hello world");
+    /* negative literal precision = precision omitted, digits must not leak */
+    NPF_TEST("42", "%.-5d", 42);
+    NPF_TEST("2b", "%.-5x", 0x2bu);
+    NPF_TEST("hello world", "%.-5s", "hello world");
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+    NPF_TEST("1.500000", "%.-3f", 1.5);
+    NPF_TEST("1.500000", "%.*f", -3, 1.5);
+#endif
 #endif
 
 #if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1) && \
     (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
     NPF_TEST("        07", "%*.*i", 10, 2, 7);
+    /* an ignored precision must not cancel the '0' flag either */
+    NPF_TEST("0000000002", "%010.*i", -1, 2);
+    NPF_TEST("-000000002", "%010.*d", -1, -2);
+    NPF_TEST("0000000002", "%010.*u", -1, 2u);
+    NPF_TEST("000000002b", "%010.*x", -1, 0x2bu);
+    NPF_TEST("0000000042", "%010.-5d", 42);
+#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
+    NPF_TEST("001.234000", "%010.*f", -5, 1.234);
+    NPF_TEST("001.500000", "%010.-5f", 1.5);
+#endif
 #endif
 
     /* ===== float ===== */

--- a/tests/unit_parse_format_spec.cc
+++ b/tests/unit_parse_format_spec.cc
@@ -249,6 +249,12 @@ TEST_CASE("npf_parse_format_spec") {
       REQUIRE(npf_parse_format_spec("%.-34u", &spec) == 6);
       REQUIRE(spec.prec_opt == NPF_FMT_SPEC_OPT_NONE);
     }
+
+    SUBCASE("period alone is precision zero") {
+      REQUIRE(npf_parse_format_spec("%.u", &spec) == 3);
+      REQUIRE(spec.prec_opt == NPF_FMT_SPEC_OPT_LITERAL);
+      REQUIRE(spec.prec == 0);
+    }
   }
 
   SUBCASE("length modifiers") {


### PR DESCRIPTION
A negative precision is "taken as if the precision were omitted", and `npf_parse_format_spec_end` already reports `prec_opt == NONE` for a literal `"%.-5d"` — but it kept accumulating the digits into `prec`, and the `prec_pad` computation reads `prec` without consulting `prec_opt`, so `"%.-5d"` zero-padded to 5 digits. This establishes the invariant `prec_opt == NONE` implies `prec == 0` in the default-precision block, which covers the literal and `".*"` paths at once and lets the star path drop its own store.

The two cases originally reported in #295 (`"%010.*i"` and `"%010.*f"` with a negative star precision) were already fixed by #360, which moved star-arg extraction ahead of the default-precision and `'0'`-flag-cancel decisions; conformance tests are added here to lock that in, along with a parse test for the previously untested "period alone is precision zero" rule.

Size at `-Os`: net **−12 bytes on cortex-m4** and **+44 on cortex-m0** — `Field Width + Precision` drops 4 bytes on both, and the cm0 cost is confined to the float-without-hex-float configurations (+16 on `Float`, +8/+12 on the sci variants); `Minimal`, `Float + Hex Float`, and `Everything` are unchanged on both cores. Three other formulations were measured and were larger overall (cm0/cm4 nets of +32/+16, +52/+28, and +80/+48).

Full suite passes: 3,194,752 conformance assertions across 4,608 objects (2,304 flag combos × 2 languages) and 47/47 doctest cases with 1,002,721 assertions.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)