### PR TITLE
Use __restrict for NPF_RESTRICT in C++ (#355)

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -43,15 +43,17 @@ typedef struct { float val; } npf_float_t;
 #define NPF_MAP_ARGS(...) __VA_ARGS__
 #endif
 
-#ifdef __cplusplus
-#define NPF_RESTRICT
-extern "C" {
-#else
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#if !defined(__cplusplus) && \
+    defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
 #define NPF_RESTRICT restrict
+#elif defined(__GNUC__) || defined(_MSC_VER)
+#define NPF_RESTRICT __restrict
 #else
 #define NPF_RESTRICT
 #endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 NPF_VISIBILITY int npf_snprintf_(char * NPF_RESTRICT buffer,


### PR DESCRIPTION
`restrict` is not a C++ keyword, so `NPF_RESTRICT` expanded to nothing in every C++ build; GCC, Clang, and MSVC all spell it `__restrict`, which also covers pre-C99 C, and the standard keyword is still preferred when it's available.

Auditing the rest of the library for restrict opportunities found none worth taking: every internal candidate (`npf_fmt_num`, `npf_parse_format_spec_end`, `npf_ftoa_rev`, `npf_etoa_rev`, `npf_ftoa_special`, the `npf_vpprintf` definition, `npf_bufputc_ctx_t::dst`) measured zero bytes across all 21 configs on cortex-m0 and cortex-m4 at `-Os`, and `npf_atoa_rev` measured +92 bytes on cortex-m0 — it's the one `NPF_NOINLINE` conversion, so restrict actually lets gcc hoist the `npf_format_spec_t` loads out of the digit loop and Thumb-1 spills under the added register pressure.

The public API is unchanged in size too, because every buffer write goes through the opaque `npf_putc` pointer that the compiler can't see past.

Sizes are byte-identical to `main` in both C and C++ (cm0 41032, cm4 41880 over the 21-config sweep); `make -j12` passes, as do pedantic `-Werror -Wall -Wextra` builds under c99, c11, c++11, and c++20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)