### PR TITLE
EXPERIMENT: fold 'z'/'t' into same-width length-modifier cases

### DIFF
--- a/nanoprintf.h
+++ b/nanoprintf.h
@@ -1563,6 +1563,37 @@ static void npf_bufputc(int c, void *ctx) {
   #define NPF_LONG_IS_INT 0
 #endif
 
+// 'z' and 't' are rarely distinct widths from 'int' or 'long'; fold them into
+// whichever same-width case already exists instead of paying for their own
+// va_arg sites.
+#if SIZE_MAX == UINT_MAX
+  #define NPF_LM_Z_INT   case NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET:
+  #define NPF_LM_Z_LONG
+  #define NPF_LM_Z_OWN 0
+#elif SIZE_MAX == ULONG_MAX && !NPF_LONG_IS_INT
+  #define NPF_LM_Z_INT
+  #define NPF_LM_Z_LONG  case NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET:
+  #define NPF_LM_Z_OWN 0
+#else
+  #define NPF_LM_Z_INT
+  #define NPF_LM_Z_LONG
+  #define NPF_LM_Z_OWN 1
+#endif
+
+#if PTRDIFF_MAX == INT_MAX
+  #define NPF_LM_T_INT   case NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT:
+  #define NPF_LM_T_LONG
+  #define NPF_LM_T_OWN 0
+#elif PTRDIFF_MAX == LONG_MAX && !NPF_LONG_IS_INT
+  #define NPF_LM_T_INT
+  #define NPF_LM_T_LONG  case NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT:
+  #define NPF_LM_T_OWN 0
+#else
+  #define NPF_LM_T_INT
+  #define NPF_LM_T_LONG
+  #define NPF_LM_T_OWN 1
+#endif
+
 int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
   npf_format_spec_t fs;
   char const *cur = format;
@@ -1687,17 +1718,27 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
     if (fs.conv_spec == NPF_FMT_SPEC_CONV_WRITEBACK) {
       switch (fs.length_modifier) {
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+        NPF_LM_Z_INT NPF_LM_T_INT
+#endif
         case NPF_FMT_SPEC_LEN_MOD_NONE: *(va_arg(args, int *)) = npf_n; break;
 #if NANOPRINTF_USE_SMALL_FORMAT_SPECIFIERS == 1
         case NPF_FMT_SPEC_LEN_MOD_SHORT: *(va_arg(args, short *)) = (short)npf_n; break;
         case NPF_FMT_SPEC_LEN_MOD_CHAR: *(va_arg(args, signed char *)) = (signed char)npf_n; break;
 #endif
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+        NPF_LM_Z_LONG NPF_LM_T_LONG
+#endif
         case NPF_FMT_SPEC_LEN_MOD_LONG: *(va_arg(args, long *)) = (long)npf_n; break;
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
         case NPF_FMT_SPEC_LEN_MOD_LARGE_LONG_LONG: *(va_arg(args, long long *)) = (long long)npf_n; break;
         case NPF_FMT_SPEC_LEN_MOD_LARGE_INTMAX: *(va_arg(args, intmax_t *)) = (intmax_t)npf_n; break;
+  #if NPF_LM_Z_OWN
         case NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET: *(va_arg(args, npf_ssize_t *)) = (npf_ssize_t)npf_n; break;
+  #endif
+  #if NPF_LM_T_OWN
         case NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT: *(va_arg(args, ptrdiff_t *)) = (ptrdiff_t)npf_n; break;
+  #endif
 #endif
         default: break;
       }
@@ -1712,13 +1753,21 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if !NPF_LONG_IS_INT || NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
         switch (fs.length_modifier) {
 #if !NPF_LONG_IS_INT
+  #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+          NPF_LM_Z_LONG NPF_LM_T_LONG
+  #endif
           NPF_EXTRACT(sval, LONG, long, long);
 #endif
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           NPF_EXTRACT(sval, LARGE_LONG_LONG, long long, long long);
           NPF_EXTRACT(sval, LARGE_INTMAX, intmax_t, intmax_t);
+  #if NPF_LM_Z_OWN
           NPF_EXTRACT(sval, LARGE_SIZET, npf_ssize_t, npf_ssize_t);
+  #endif
+  #if NPF_LM_T_OWN
           NPF_EXTRACT(sval, LARGE_PTRDIFFT, ptrdiff_t, ptrdiff_t);
+  #endif
+          NPF_LM_Z_INT NPF_LM_T_INT
 #endif
           default:
 #endif
@@ -1745,13 +1794,21 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
 #if !NPF_LONG_IS_INT || NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
           switch (fs.length_modifier) {
 #if !NPF_LONG_IS_INT
+  #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+            NPF_LM_Z_LONG NPF_LM_T_LONG
+  #endif
             NPF_EXTRACT(val, LONG, unsigned long, unsigned long);
 #endif
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
             NPF_EXTRACT(val, LARGE_LONG_LONG, unsigned long long, unsigned long long);
             NPF_EXTRACT(val, LARGE_INTMAX, uintmax_t, uintmax_t);
+  #if NPF_LM_Z_OWN
             NPF_EXTRACT(val, LARGE_SIZET, size_t, size_t);
+  #endif
+  #if NPF_LM_T_OWN
             NPF_EXTRACT(val, LARGE_PTRDIFFT, npf_uptrdiff_t, npf_uptrdiff_t);
+  #endif
+            NPF_LM_Z_INT NPF_LM_T_INT
 #endif
             default:
 #endif


### PR DESCRIPTION
**Draft / measurement only — not proposed for merge as-is.** Opened to collect the avr2/avr5 numbers and the `ARCH=32` conformance run, neither of which I can produce locally.

Context: evaluating what, if anything, is still worth salvaging from #312 now that `main` has diverged.

## What `main` already does

`main` already exploits `LONG_MAX == INT_MAX` (`NPF_LONG_IS_INT`), already truncates `h`/`hh` after an `int` extraction instead of giving them their own `va_arg` sites, already drops the `L` float branch under `LDBL_MANT_DIG == DBL_MANT_DIG`, and has deleted the `NPF_EXTRACT(LONG_DOUBLE, …)` / `NPF_WRITEBACK(LONG_DOUBLE, double)` cases (#311). The only idea in #312 that `main` has *not* absorbed is collapsing the redundant `ll`/`j`/`z`/`t` cases.

## Negative results, measured

Two things that sound like they should help, don't:

1. **Aliasing `j` onto `ll` is a wash or a regression** — cm0 Everything +20 bytes locally. gcc already tail-merges those two case bodies, because `intmax_t` *is* `long long`; an explicit shared case label only perturbs the switch lowering. This answers the question raised in #312: arm-gcc does figure it out on its own.

2. **Hoisting the `h`/`hh` truncation out of the `default:` arm does not let gcc merge `z`/`t` with `default` on its own** — cm0 Everything +4, cm4 Everything +12. Making the case bodies textually identical is not sufficient; explicit compile-time selection is required.

## What this PR does

Fold `z` and `t` into whichever same-width case already exists (int-width, long-width, or keep their own), selected by `SIZE_MAX` / `PTRDIFF_MAX`. Three sites: the signed switch, the unsigned switch, and the write-back switch.

## Measured, CI toolchain, `-Os`

Baseline is #376's `size-reports` job (head `08bd5b2f`, identical header content to `main` @ `dec3da2`).

| platform | config | before | after | delta |
| --- | --- | --- | --- | --- |
| avr2 | Everything | 14010 | 13806 | **-204** |
| avr2 | Everything, no precision | 12230 | 12102 | **-128** |
| avr5 | Everything | 13274 | 13130 | **-144** |
| avr5 | Everything, no precision | 11290 | 11186 | **-104** |
| cm0 | Everything | 3424 | 3404 | **-20** |
| cm0 | Everything, no precision | 2944 | 2896 | **-48** |
| cm4 | Everything | 3508 | 3468 | **-40** |
| cm4 | Everything, no precision | 3060 | 3012 | **-48** |
| linux x64 | Everything | 5458 | 5389 | **-69** |
| linux x64 | Everything, no precision | 4819 | 4796 | **-23** |

**Every other configuration is byte-identical on all five platforms.** The macros live entirely inside `NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS` guards. The AVR wins are the largest because `int` is 16-bit there, so `size_t`/`ptrdiff_t` fold into the int case and 16-bit codegen for the dropped 64-bit arms is expensive.

(Local arm-none-eabi 15.2.Rel1 gives -32/-36 cm0 and -44/-60 cm4 — different toolchain than the CI image, same direction.)

## Test coverage

- Host suite passes: `PASSED: 3468096 assertions across 4864 objects (2432 flag combos, x 2 langs)`. LP64 exercises the long-width fold.
- The `ARCH=32` clang jobs are the only configuration exercising the int-width fold against a real `printf`. `tests/conformance.c` covers `%zd`/`%zu`/`%td`/`%jd`/`%lld` and the `%zn`/`%tn`/`%jn`/`%lln` write-backs.
- avr2/avr5 also take the int-width branch, though only for size, not execution.

## Note on the #312 approach specifically

#312 removed the enum constant when a modifier was aliased, and separately emitted an alias definition — but the alias definitions only covered the `long long` and `long` targets, not `int`. On a 16-bit target (`SIZE_MAX == UINT_MAX`, `PTRDIFF_MAX == INT_MAX`, both `!=` the `long`/`long long` maxes) the `IS_ALIASED` macros are true, so the enumerators are dropped, but no alias is ever defined, and the untouched `case 'z':` / `case 't':` lines in `npf_parse_format_spec` reference undefined identifiers. Reproduced against a standalone copy of that enum with AVR limits:

```
error: use of undeclared identifier 'NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET'
error: use of undeclared identifier 'NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT'
```

That is exactly avr2/avr5 — the platforms with the largest win available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
