### PR TITLE
build: add a host-toolchain path around envy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,11 +162,7 @@ jobs:
           call "%VSPATH%\VC\Auxiliary\Build\vcvars${{ matrix.architecture }}.bat"
           call build.bat --cfg ${{ matrix.configuration }} -v --arch ${{ matrix.architecture }}
 
-  # Guards the no-envy path in README "Building without envy". Deliberately not the CI
-  # container and deliberately no envy: the runner's own gcc and python3, and a doctest.h
-  # fetched by hand, are exactly what someone on a blocked network or an unsupported
-  # platform has to work with. One shard -- the other jobs cover the flag matrix, this one
-  # covers the toolchain.
+  # Guards the DOCTEST_H path: no container, no envy, the runner's own gcc and python3.
   host-tools:
     if: github.event.inputs.size_only != 'true'
     runs-on: ubuntu-latest
@@ -174,8 +170,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # The version envy.lua pins, kept in step by hand. Nothing breaks if they drift;
-      # what is under test is that the override is honored, not which doctest it names.
       - name: doctest.h
         run: |
           mkdir -p "${RUNNER_TEMP}/doctest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,29 @@ jobs:
           call "%VSPATH%\VC\Auxiliary\Build\vcvars${{ matrix.architecture }}.bat"
           call build.bat --cfg ${{ matrix.configuration }} -v --arch ${{ matrix.architecture }}
 
+  # Guards the no-envy path in README "Building without envy". Deliberately not the CI
+  # container and deliberately no envy: the runner's own gcc and python3, and a doctest.h
+  # fetched by hand, are exactly what someone on a blocked network or an unsupported
+  # platform has to work with. One shard -- the other jobs cover the flag matrix, this one
+  # covers the toolchain.
+  host-tools:
+    if: github.event.inputs.size_only != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # The version envy.lua pins, kept in step by hand. Nothing breaks if they drift;
+      # what is under test is that the override is honored, not which doctest it names.
+      - name: doctest.h
+        run: |
+          mkdir -p "${RUNNER_TEMP}/doctest"
+          curl -fsSL -o "${RUNNER_TEMP}/doctest/doctest.h" \
+            https://raw.githubusercontent.com/doctest/doctest/v2.5.3/doctest/doctest.h
+
+      - name: Build without envy
+        run: make -j$(nproc) DOCTEST_H="${RUNNER_TEMP}/doctest/doctest.h" SHARD=1/4 VERBOSE=1
+
   size-reports:
     runs-on: ubuntu-latest
 
@@ -223,7 +246,7 @@ jobs:
         run: ./bin/python3 tests/avr_int16.py
 
   all-checks-pass:
-    needs: [lint, sanitizers, linux-x64, linux-arm64, macos, win, size-reports, avr-int16]
+    needs: [lint, sanitizers, linux-x64, linux-arm64, macos, win, host-tools, size-reports, avr-int16]
     # A size_only dispatch skips most of the jobs above, and a skipped dependency
     # would skip this job too, leaving the required check with nothing to report.
     if: always()

--- a/Makefile
+++ b/Makefile
@@ -14,22 +14,37 @@ VERBOSE ?=
 BUILD := build
 GEN   := $(BUILD)/generated
 
-# --- envy-managed toolchain ---
+# --- Toolchain ---
+# The pinned toolchain comes from envy by default. Supplying DOCTEST_H from the command
+# line or the environment opts out of it entirely -- envy is never invoked, nothing is
+# downloaded -- for hosts that must bring their own tools: a blocked or absent network, an
+# air-gap, a platform envy has no build for. DOCTEST_H and PYTHON3 are the whole toolchain
+# that path needs; no ruff, since nothing here lints. See README "Building without envy".
 ENVY := ./bin/envy
 
-# Installed up front so a fresh clone running `make -j12` has the whole toolchain
-# before the first rule fires, not one package at a time as the shims are reached.
 ifneq ($(MAKECMDGOALS),clean)
-  ENVY_INSTALLED := $(shell $(ENVY) install && echo ok)
-  ifneq ($(ENVY_INSTALLED),ok)
-    $(error envy install failed)
+  ifeq ($(origin DOCTEST_H),undefined)
+    # Installed up front so a fresh clone running `make -j12` has the whole toolchain
+    # before the first rule fires, not one package at a time as the shims are reached.
+    ENVY_INSTALLED := $(shell $(ENVY) install && echo ok)
+    ifneq ($(ENVY_INSTALLED),ok)
+      $(error envy install failed)
+    endif
+
+    PYTHON3   ?= ./bin/python3
+    DOCTEST_H := $(shell $(ENVY) -q product doctest_cpp_h)
+    ifeq ($(DOCTEST_H),)
+      $(error envy could not resolve doctest_cpp_h)
+    endif
+  else
+    # Not ./bin/python3: that shim re-execs envy, which is the whole thing being opted out
+    # of. Override PYTHON3 to name a specific interpreter.
+    PYTHON3 ?= python3
+    ifeq ($(wildcard $(DOCTEST_H)),)
+      $(error DOCTEST_H=$(DOCTEST_H) does not exist)
+    endif
   endif
 
-  PYTHON3     ?= ./bin/python3
-  DOCTEST_H   := $(shell $(ENVY) -q product doctest_cpp_h)
-  ifeq ($(DOCTEST_H),)
-    $(error envy could not resolve doctest_cpp_h)
-  endif
   # -isystem, not -I: doctest.h is not ours to keep clean under -Weverything -Werror.
   DOCTEST_INC := -isystem $(dir $(DOCTEST_H))
 endif

--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,15 @@ VERBOSE ?=
 BUILD := build
 GEN   := $(BUILD)/generated
 
-# --- Toolchain ---
-# The pinned toolchain comes from envy by default. Supplying DOCTEST_H from the command
-# line or the environment opts out of it entirely -- envy is never invoked, nothing is
-# downloaded -- for hosts that must bring their own tools: a blocked or absent network, an
-# air-gap, a platform envy has no build for. DOCTEST_H and PYTHON3 are the whole toolchain
-# that path needs; no ruff, since nothing here lints. See README "Building without envy".
+# --- envy-managed packages ---
+# Supplying DOCTEST_H opts out: envy is never invoked and nothing is downloaded, so
+# DOCTEST_H and PYTHON3 are all the build needs. See README "Building without envy".
 ENVY := ./bin/envy
 
 ifneq ($(MAKECMDGOALS),clean)
   ifeq ($(origin DOCTEST_H),undefined)
-    # Installed up front so a fresh clone running `make -j12` has the whole toolchain
-    # before the first rule fires, not one package at a time as the shims are reached.
+    # Installed up front so a fresh clone running `make -j12` has every package before the
+    # first rule fires, not one at a time as the shims are reached.
     ENVY_INSTALLED := $(shell $(ENVY) install && echo ok)
     ifneq ($(ENVY_INSTALLED),ok)
       $(error envy install failed)
@@ -37,8 +34,7 @@ ifneq ($(MAKECMDGOALS),clean)
       $(error envy could not resolve doctest_cpp_h)
     endif
   else
-    # Not ./bin/python3: that shim re-execs envy, which is the whole thing being opted out
-    # of. Override PYTHON3 to name a specific interpreter.
+    # Not ./bin/python3: that shim re-execs envy.
     PYTHON3 ?= python3
     ifeq ($(wildcard $(DOCTEST_H)),)
       $(error DOCTEST_H=$(DOCTEST_H) does not exist)

--- a/README.md
+++ b/README.md
@@ -359,53 +359,28 @@ To get the environment and run tests:
 
 This will build all of the unit, conformance, and compilation tests for your host environment. Any test failures will return a non-zero exit code.
 
-The only things you need on your host are a C/C++ compiler, `make`, and the `curl`/`git`/`tar` that the bootstrap script uses. The rest of what the tests need — a Python interpreter, [ruff](https://docs.astral.sh/ruff/), and the [doctest](https://github.com/doctest/doctest) header — is pinned in `envy.lua` and installed on demand by [envy](https://github.com/envy-package-manager/envy) through the committed `bin/envy` bootstrap script, which `make` and `build.bat` invoke for you. Packages land in `build/envy-cache` rather than a machine-wide cache, so everything this repo generates is under `build/`. `make clean` removes the build products but keeps the cache; `rm -rf build` takes the toolchain with it. Point `ENVY_CACHE_ROOT` at a shared cache if you would rather have one copy across projects.
-
-None of this touches anyone who is only *using* nanoprintf. The header is self-contained and the release assets are a header and a source bundle; the toolchain below exists to run the test suite.
-
-### Restricted or offline networks
-
-A first build fetches about 140 MB, all of it from GitHub:
-
-| What | Where from | Size |
-| --- | --- | --- |
-| the `envy` binary | `github.com/envy-package-manager/envy` release assets | 4 MB |
-| package specs | `git clone` of `github.com/envy-package-manager/package-specs` | 170 KB |
-| CPython | `github.com/astral-sh/python-build-standalone` release assets | 123 MB |
-| ruff | `github.com/astral-sh/ruff` release assets | 11 MB |
-| `doctest.h` | `raw.githubusercontent.com` | 363 KB |
-
-Where that is slow, filtered, or simply not there, in rough order of least to most work:
-
-- **A proxy covers the downloads.** `http_proxy`, `https_proxy`, and `no_proxy` are honored both by the bootstrap script and by every package fetch envy makes. The one exception is the package-spec `git clone`, which goes through libgit2 and connects to `github.com` directly whatever those variables say; configure a proxy in git itself, or seed `specs/` from another machine as below.
-- **`ENVY_CACHE_ROOT` buys one copy.** Point it somewhere outside the repo and every clone, worktree, and sibling project shares a single populated cache, so the 140 MB is paid once per machine instead of once per checkout.
-- **Prime a cache and carry it in.** On a machine that does have access, `./bin/envy export -o depot` writes one `.tar.zst` per package. Copy `depot/` plus the cache's `specs/` and `envy/` directories to the target machine, then `./bin/envy import --dir depot` and build; nothing reaches the network. The archives are keyed by platform, so the two machines have to agree on OS and architecture. Copying the whole `build/envy-cache` tree works just as well and skips the export.
-- **Mirror it.** `ENVY_MIRROR` (or an `@envy mirror` directive in `envy.lua`) redirects the bootstrap to your own copy of the envy release, and a `PACKAGE_DEPOTS` global in `envy.lua` does the same for the packages — an internal artifact server, an object-store bucket, whatever is reachable. `envy export --depot-prefix` builds the depot manifest to publish. The `@envy sha256sums` pin in `envy.lua` attests the envy binary against a hash held in this repo rather than one fetched alongside it, and each package spec carries its own hash, so an untrusted mirror cannot substitute anything.
+The only things you need on your host are a C/C++ compiler, `make`, and the `curl`/`git`/`tar` that the bootstrap script uses. The rest of what the tests need — a Python interpreter, [ruff](https://docs.astral.sh/ruff/), and the [doctest](https://github.com/doctest/doctest) header — is pinned in `envy.lua` and installed on demand by [envy](https://github.com/envy-package-manager/envy) through the committed `bin/envy` bootstrap script, which `make` and `build.bat` invoke for you. Packages land in `build/envy-cache` rather than a machine-wide cache, so everything this repo generates is under `build/`. `make clean` removes the build products but keeps the cache; `rm -rf build` takes the packages with it. Point `ENVY_CACHE_ROOT` at a shared cache if you would rather have one copy across projects.
 
 ### Building without envy
 
-Setting `DOCTEST_H` opts out completely — envy is never invoked and nothing is downloaded:
+Using nanoprintf needs none of the above; the header is self-contained. Running the tests fetches about 140 MB from GitHub, and where that is slow or filtered, `http_proxy` and `https_proxy` are honored by the bootstrap script and by every package fetch. The package-spec `git clone` goes through libgit2 and connects directly whatever they say.
+
+Setting `DOCTEST_H` skips envy altogether — nothing is downloaded and no package manager runs:
 
 ```sh
 make -j12 DOCTEST_H=/path/to/doctest.h
 ```
-
-That path wants a C/C++ compiler, `make`, a Python interpreter at 3.10 or newer, and a copy of `doctest.h`, which is a single self-contained header from any source you like: a release, a distribution package, a mirror, a coworker. `PYTHON3` names the interpreter and defaults to whatever `python3` on `PATH` resolves to. ruff is not needed; nothing in the build lints.
-
-On Windows the same escape hatch is an environment variable, since `build.bat` otherwise runs the interpreter envy pins:
 
 ```bat
 set NPF_DOCTEST_H=C:\path\to\doctest.h
 build.bat
 ```
 
-This is the path to reach for on an air-gapped machine, or on a platform envy has no build for. CI exercises it on every pull request, so it does not rot.
+That path wants a C/C++ compiler, `make`, Python 3.10 or newer, and a copy of `doctest.h` from wherever you like. `PYTHON3` names the interpreter and defaults to `python3` on `PATH`. ruff is not needed; nothing in the build lints.
 
 nanoprintf uses GitHub Actions for all continuous integration builds. The GitHub Linux builds use [this](https://github.com/charlesnicholson/docker-images/packages/751874) Docker image from [my Docker repository](https://github.com/charlesnicholson/docker-images).
 
 The matrix builds [Debug, Release] x [32-bit, 64-bit] x [Mac, Windows, Linux] x [gcc, clang, msvc], minus the 32-bit clang Mac configurations.
-
-Some conformance cases are ported from the [printf test suite](https://github.com/eyalroz/printf/blob/master/test/test_suite.cpp) credited in [Acknowledgments](#acknowledgments), rewritten as `NPF_TEST` cases in `tests/conformance.c`. They build and run with everything else: no submodule to retrieve, no flag to pass. No third-party code is vendored here, so the whole repository is under nanoprintf's own [license](LICENSE).
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -361,11 +361,51 @@ This will build all of the unit, conformance, and compilation tests for your hos
 
 The only things you need on your host are a C/C++ compiler, `make`, and the `curl`/`git`/`tar` that the bootstrap script uses. The rest of what the tests need — a Python interpreter, [ruff](https://docs.astral.sh/ruff/), and the [doctest](https://github.com/doctest/doctest) header — is pinned in `envy.lua` and installed on demand by [envy](https://github.com/envy-package-manager/envy) through the committed `bin/envy` bootstrap script, which `make` and `build.bat` invoke for you. Packages land in `build/envy-cache` rather than a machine-wide cache, so everything this repo generates is under `build/`. `make clean` removes the build products but keeps the cache; `rm -rf build` takes the toolchain with it. Point `ENVY_CACHE_ROOT` at a shared cache if you would rather have one copy across projects.
 
+None of this touches anyone who is only *using* nanoprintf. The header is self-contained and the release assets are a header and a source bundle; the toolchain below exists to run the test suite.
+
+### Restricted or offline networks
+
+A first build fetches about 140 MB, all of it from GitHub:
+
+| What | Where from | Size |
+| --- | --- | --- |
+| the `envy` binary | `github.com/envy-package-manager/envy` release assets | 4 MB |
+| package specs | `git clone` of `github.com/envy-package-manager/package-specs` | 170 KB |
+| CPython | `github.com/astral-sh/python-build-standalone` release assets | 123 MB |
+| ruff | `github.com/astral-sh/ruff` release assets | 11 MB |
+| `doctest.h` | `raw.githubusercontent.com` | 363 KB |
+
+Where that is slow, filtered, or simply not there, in rough order of least to most work:
+
+- **A proxy covers the downloads.** `http_proxy`, `https_proxy`, and `no_proxy` are honored both by the bootstrap script and by every package fetch envy makes. The one exception is the package-spec `git clone`, which goes through libgit2 and connects to `github.com` directly whatever those variables say; configure a proxy in git itself, or seed `specs/` from another machine as below.
+- **`ENVY_CACHE_ROOT` buys one copy.** Point it somewhere outside the repo and every clone, worktree, and sibling project shares a single populated cache, so the 140 MB is paid once per machine instead of once per checkout.
+- **Prime a cache and carry it in.** On a machine that does have access, `./bin/envy export -o depot` writes one `.tar.zst` per package. Copy `depot/` plus the cache's `specs/` and `envy/` directories to the target machine, then `./bin/envy import --dir depot` and build; nothing reaches the network. The archives are keyed by platform, so the two machines have to agree on OS and architecture. Copying the whole `build/envy-cache` tree works just as well and skips the export.
+- **Mirror it.** `ENVY_MIRROR` (or an `@envy mirror` directive in `envy.lua`) redirects the bootstrap to your own copy of the envy release, and a `PACKAGE_DEPOTS` global in `envy.lua` does the same for the packages — an internal artifact server, an object-store bucket, whatever is reachable. `envy export --depot-prefix` builds the depot manifest to publish. The `@envy sha256sums` pin in `envy.lua` attests the envy binary against a hash held in this repo rather than one fetched alongside it, and each package spec carries its own hash, so an untrusted mirror cannot substitute anything.
+
+### Building without envy
+
+Setting `DOCTEST_H` opts out completely — envy is never invoked and nothing is downloaded:
+
+```sh
+make -j12 DOCTEST_H=/path/to/doctest.h
+```
+
+That path wants a C/C++ compiler, `make`, a Python interpreter at 3.10 or newer, and a copy of `doctest.h`, which is a single self-contained header from any source you like: a release, a distribution package, a mirror, a coworker. `PYTHON3` names the interpreter and defaults to whatever `python3` on `PATH` resolves to. ruff is not needed; nothing in the build lints.
+
+On Windows the same escape hatch is an environment variable, since `build.bat` otherwise runs the interpreter envy pins:
+
+```bat
+set NPF_DOCTEST_H=C:\path\to\doctest.h
+build.bat
+```
+
+This is the path to reach for on an air-gapped machine, or on a platform envy has no build for. CI exercises it on every pull request, so it does not rot.
+
 nanoprintf uses GitHub Actions for all continuous integration builds. The GitHub Linux builds use [this](https://github.com/charlesnicholson/docker-images/packages/751874) Docker image from [my Docker repository](https://github.com/charlesnicholson/docker-images).
 
 The matrix builds [Debug, Release] x [32-bit, 64-bit] x [Mac, Windows, Linux] x [gcc, clang, msvc], minus the 32-bit clang Mac configurations.
 
-One test suite is a fork from the [printf test suite](), which is MIT licensed. It exists as a submodule for licensing purposes- nanoprintf is public domain, so this particular test suite is optional and excluded by default. To build it, retrieve it by updating submodules and add the `--paland` flag to your `./b` invocation. It is not required to use nanoprintf at all.
+Some conformance cases are ported from the [printf test suite](https://github.com/eyalroz/printf/blob/master/test/test_suite.cpp) credited in [Acknowledgments](#acknowledgments), rewritten as `NPF_TEST` cases in `tests/conformance.c`. They build and run with everything else: no submodule to retrieve, no flag to pass. No third-party code is vendored here, so the whole repository is under nanoprintf's own [license](LICENSE).
 
 ## Acknowledgments
 

--- a/build.bat
+++ b/build.bat
@@ -2,6 +2,13 @@
 setlocal
 cd /d "%~dp0"
 
-REM The shim resolves (and installs, if needed) the interpreter envy pins.
-call bin\python3.bat build.py %*
+REM NPF_DOCTEST_H names a host doctest.h and opts out of envy: the interpreter has to come
+REM from PATH too, since the shim below is what re-execs envy. See README "Building
+REM without envy". Otherwise the shim resolves (and installs, if needed) the interpreter
+REM envy pins.
+if defined NPF_DOCTEST_H (
+  python build.py %*
+) else (
+  call bin\python3.bat build.py %*
+)
 exit /b %ERRORLEVEL%

--- a/build.bat
+++ b/build.bat
@@ -2,10 +2,8 @@
 setlocal
 cd /d "%~dp0"
 
-REM NPF_DOCTEST_H names a host doctest.h and opts out of envy: the interpreter has to come
-REM from PATH too, since the shim below is what re-execs envy. See README "Building
-REM without envy". Otherwise the shim resolves (and installs, if needed) the interpreter
-REM envy pins.
+REM NPF_DOCTEST_H opts out of envy, so the interpreter comes from PATH: the shim re-execs
+REM envy. Otherwise the shim resolves (and installs, if needed) the interpreter envy pins.
 if defined NPF_DOCTEST_H (
   python build.py %*
 ) else (

--- a/build.py
+++ b/build.py
@@ -52,13 +52,7 @@ def _envy_product(name: str) -> str:
 
 
 def _doctest_include_dir() -> pathlib.Path:
-    """Directory to put on the /I line for doctest.h.
-
-    NPF_DOCTEST_H names a host copy and opts out of envy entirely, the Makefile's
-    DOCTEST_H by another name; build.bat routes around the envy python shim when it is
-    set. For a blocked or absent network, or a platform envy has no build for. See
-    README "Building without envy".
-    """
+    """Include directory for doctest.h. NPF_DOCTEST_H names a host copy and skips envy."""
     override = os.environ.get("NPF_DOCTEST_H")
     if not override:
         return pathlib.Path(_envy_product("doctest_cpp_h")).parent

--- a/build.py
+++ b/build.py
@@ -51,6 +51,24 @@ def _envy_product(name: str) -> str:
     return result.stdout.strip()
 
 
+def _doctest_include_dir() -> pathlib.Path:
+    """Directory to put on the /I line for doctest.h.
+
+    NPF_DOCTEST_H names a host copy and opts out of envy entirely, the Makefile's
+    DOCTEST_H by another name; build.bat routes around the envy python shim when it is
+    set. For a blocked or absent network, or a platform envy has no build for. See
+    README "Building without envy".
+    """
+    override = os.environ.get("NPF_DOCTEST_H")
+    if not override:
+        return pathlib.Path(_envy_product("doctest_cpp_h")).parent
+    doctest_h = pathlib.Path(override).resolve()
+    if not doctest_h.is_file():
+        msg = f"NPF_DOCTEST_H={override} does not exist"
+        raise ValueError(msg)
+    return doctest_h.parent
+
+
 def _run(
     args: list[str | pathlib.Path],
     *,
@@ -160,7 +178,7 @@ def _build_unit_tests(args: argparse.Namespace) -> bool:
     cxx_flags = [
         "/nologo",
         *_cl_opt_flags(args.cfg),
-        f"/I{pathlib.Path(_envy_product('doctest_cpp_h')).parent}",
+        f"/I{_doctest_include_dir()}",
         "/std:c++20",
         "/EHsc",
         "/W4",

--- a/envy.lua
+++ b/envy.lua
@@ -5,6 +5,7 @@
 
 -- @envy schema "1"
 -- @envy version "0.1.2"
+-- @envy sha256sums "8271f14cf53fe0925674d960096f6a14c910a9df5bedc0081e7d55ed157ca7aa"
 -- @envy bin "bin"
 -- @envy cache-posix "build/envy-cache"
 -- @envy cache-win "build\envy-cache"


### PR DESCRIPTION
A first build reaches GitHub for about 140 MB, one of those fetches from `raw.githubusercontent.com`, so on a filtered network — mainland China most notably — there was no way to build at all once the packages moved to envy.

Setting `DOCTEST_H` (`NPF_DOCTEST_H` on Windows) now skips envy altogether: a C/C++ compiler, `make`, Python 3.10 or newer, and one header are all that path needs, nothing is downloaded, and a new `host-tools` CI job builds that way on a bare runner so it cannot rot. The README also notes that `http_proxy`/`https_proxy` cover every package fetch, while the package-spec clone goes through libgit2 and connects directly whatever they say. `@envy sha256sums` pins the hash of the release's `SHA256SUMS` here rather than fetching it beside the archive, closing the last unattested download.

Also drops the stale note about the paland suite, which described a submodule, a `--paland` flag, and `./b`, none of which exist. `nanoprintf.h` is untouched, so there is no size impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
