### PR TITLE
build: /WX on every MSVC target, and no more C4127

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,6 +11,13 @@ import sys
 _SCRIPT_PATH = pathlib.Path(__file__).resolve().parent
 _ENVY = _SCRIPT_PATH / "bin" / ("envy.bat" if os.name == "nt" else "envy")
 
+# /WX is MSVC's -Werror, and it belongs on every target. Three of the compile-only
+# ones built at the default warning level, so anything the unit and conformance
+# builds would have refused went unnoticed there. The suppressions are the
+# off-by-default level-4 notes any of these can trip -- a '..' in an include path,
+# and the three inline-expansion remarks -- none of which say anything about the code.
+_CL_WARN_FLAGS = ["/W4", "/WX", "/wd4464", "/wd4514", "/wd4710", "/wd4711"]
+
 # Globbed, not listed: the Makefile compiles the same set, and a hand-maintained copy
 # here silently missed every unit test added since it was written.
 _UNIT_SRCS = sorted(
@@ -175,12 +182,8 @@ def _build_unit_tests(args: argparse.Namespace) -> bool:
         f"/I{_doctest_include_dir()}",
         "/std:c++20",
         "/EHsc",
-        "/W4",
-        "/WX",
-        "/wd4464",
-        "/wd4514",
-        "/wd4710",
-        "/wd4711",
+        *_CL_WARN_FLAGS,
+        # doctest.h's own level-4 noise, not nanoprintf's.
         "/wd4619",
         "/wd4820",
         "/wd5039",
@@ -256,17 +259,17 @@ def _build_compile_only(args: argparse.Namespace) -> bool:
         # (name, extra_cl_flags, source_files)
         (
             "npf_static",
-            ["/nologo", *opt],
+            ["/nologo", *opt, *_CL_WARN_FLAGS],
             ["tests/static_nanoprintf.c", "tests/static_main.c"],
         ),
         (
             "npf_include_multiple",
-            ["/nologo", *opt, "/W4", "/WX", "/wd4464", "/wd4514", "/wd4710", "/wd4711"],
+            ["/nologo", *opt, *_CL_WARN_FLAGS],
             ["tests/include_multiple.c"],
         ),
         (
             "use_npf_directly",
-            ["/nologo", *opt, "/std:c++20", "/EHsc"],
+            ["/nologo", *opt, *_CL_WARN_FLAGS, "/std:c++20", "/EHsc"],
             [
                 "examples/use_npf_directly/your_project_nanoprintf.cc",
                 "examples/use_npf_directly/main.cc",
@@ -274,7 +277,7 @@ def _build_compile_only(args: argparse.Namespace) -> bool:
         ),
         (
             "wrap_npf",
-            ["/nologo", *opt, "/std:c++20", "/EHsc"],
+            ["/nologo", *opt, *_CL_WARN_FLAGS, "/std:c++20", "/EHsc"],
             [
                 "examples/wrap_npf/your_project_printf.cc",
                 "examples/wrap_npf/main.cc",

--- a/tests/conformance.c
+++ b/tests/conformance.c
@@ -1334,15 +1334,20 @@ int NPF_TEST_FUNC(void) {
     /* Truncation of the promoted argument. The expectation comes from the type,
        so these hold on a target where int_leastN_t is wider than N bits (any
        CHAR_BIT other than 8) as well. Skipped where the type is wider than int,
-       since then the argument would not be an int in the first place. */
+       since then the argument would not be an int in the first place.
+
+       The preprocessor draws that line, from the type's maximum rather than its
+       sizeof: a signed type is no wider than int exactly when its maximum fits in
+       INT_MAX. An `if` over the sizeof would say the same thing, but a condition
+       the compiler can fold is what MSVC's C4127 objects to, and C has no
+       `if constexpr` to say "yes, on purpose" with. */
 #define NPF_TEST_WPROMO(fmt, type, raw) do { \
-      if (sizeof(type) <= sizeof(int)) { \
-        char npf_wp_exp[32]; \
-        snprintf(npf_wp_exp, sizeof(npf_wp_exp), "%lld", (long long)(type)(raw)); \
-        NPF_TEST_DYN(npf_wp_exp, fmt, (int)(raw)); \
-      } \
+      char npf_wp_exp[32]; \
+      snprintf(npf_wp_exp, sizeof(npf_wp_exp), "%lld", (long long)(type)(raw)); \
+      NPF_TEST_DYN(npf_wp_exp, fmt, (int)(raw)); \
     } while (0)
 
+#if INT_LEAST8_MAX <= INT_MAX
     NPF_TEST_WPROMO("%w8d", int_least8_t, 0);
     NPF_TEST_WPROMO("%w8d", int_least8_t, 127);
     NPF_TEST_WPROMO("%w8d", int_least8_t, 128);
@@ -1352,50 +1357,80 @@ int NPF_TEST_FUNC(void) {
     NPF_TEST_WPROMO("%w8d", int_least8_t, -1);
     NPF_TEST_WPROMO("%w8i", int_least8_t, INT_MAX);
     NPF_TEST_WPROMO("%w8i", int_least8_t, INT_MIN);
+#endif
+#if INT_LEAST16_MAX <= INT_MAX
     NPF_TEST_WPROMO("%w16d", int_least16_t, 32767);
     NPF_TEST_WPROMO("%w16d", int_least16_t, 32768);
     NPF_TEST_WPROMO("%w16d", int_least16_t, 65535);
     NPF_TEST_WPROMO("%w16d", int_least16_t, 65536);
     NPF_TEST_WPROMO("%w16i", int_least16_t, INT_MAX);
+#endif
+#if INT_FAST8_MAX <= INT_MAX
     NPF_TEST_WPROMO("%wf8d", int_fast8_t, 300);
     NPF_TEST_WPROMO("%wf8d", int_fast8_t, -1);
+#endif
+#if INT_FAST16_MAX <= INT_MAX
     NPF_TEST_WPROMO("%wf16d", int_fast16_t, 70000);
     NPF_TEST_WPROMO("%wf16d", int_fast16_t, -1);
+#endif
 #undef NPF_TEST_WPROMO
 
     /* The design claim, asserted directly: at a width whose stdint type is the
-       same type a classic modifier names, the two specifiers agree exactly. */
-#define NPF_TEST_WSAME(cond, wfmt, cfmt, ...) do { \
-      if (cond) { \
-        char npf_wq_a[64], npf_wq_b[64]; \
-        npf_snprintf(npf_wq_a, sizeof(npf_wq_a), wfmt, __VA_ARGS__); \
-        npf_snprintf(npf_wq_b, sizeof(npf_wq_b), cfmt, __VA_ARGS__); \
-        if (strcmp(npf_wq_a, npf_wq_b) != 0) { \
-          fprintf(stderr, "FAIL [%s:%d]: \"%s\"=\"%s\" \"%s\"=\"%s\"\n", \
-                  __FILE__, __LINE__, wfmt, npf_wq_a, cfmt, npf_wq_b); \
-          ++npf_test_fail_count; \
-        } else { ++npf_test_pass_count; } \
-      } \
+       same type a classic modifier names, the two specifiers agree exactly.
+
+       Which widths those are is again a question for the preprocessor, and again
+       answered through the maxima: two integer types of one signedness hold the
+       same values exactly when their maxima match, which is the property these
+       cases actually rest on. */
+#define NPF_TEST_WSAME(wfmt, cfmt, ...) do { \
+      char npf_wq_a[64], npf_wq_b[64]; \
+      npf_snprintf(npf_wq_a, sizeof(npf_wq_a), wfmt, __VA_ARGS__); \
+      npf_snprintf(npf_wq_b, sizeof(npf_wq_b), cfmt, __VA_ARGS__); \
+      if (strcmp(npf_wq_a, npf_wq_b) != 0) { \
+        fprintf(stderr, "FAIL [%s:%d]: \"%s\"=\"%s\" \"%s\"=\"%s\"\n", \
+                __FILE__, __LINE__, wfmt, npf_wq_a, cfmt, npf_wq_b); \
+        ++npf_test_fail_count; \
+      } else { ++npf_test_pass_count; } \
     } while (0)
 
-    NPF_TEST_WSAME(sizeof(int_least8_t) == sizeof(signed char), "%w8d", "%hhd", 300);
-    NPF_TEST_WSAME(sizeof(int_least8_t) == sizeof(signed char), "%w8i", "%hhi", -1);
-    NPF_TEST_WSAME(sizeof(uint_least8_t) == sizeof(unsigned char), "%w8u", "%hhu", 511u);
-    NPF_TEST_WSAME(sizeof(uint_least8_t) == sizeof(unsigned char), "%w8x", "%hhx", UINT_MAX);
-    NPF_TEST_WSAME(sizeof(uint_least8_t) == sizeof(unsigned char), "%w8o", "%hho", UINT_MAX);
-    NPF_TEST_WSAME(sizeof(int_least16_t) == sizeof(short), "%w16d", "%hd", 70000);
-    NPF_TEST_WSAME(sizeof(uint_least16_t) == sizeof(unsigned short), "%w16u", "%hu", UINT_MAX);
-    NPF_TEST_WSAME(sizeof(int_least32_t) == sizeof(int), "%w32d", "%d", (int32_t)-12345);
-    NPF_TEST_WSAME(sizeof(int_fast8_t) == sizeof(signed char), "%wf8d", "%hhd", 300);
-    NPF_TEST_WSAME(sizeof(int_fast8_t) == sizeof(int), "%wf8d", "%d", 300);
-    NPF_TEST_WSAME(sizeof(int_fast16_t) == sizeof(int), "%wf16d", "%d", 70000);
-#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-    NPF_TEST_WSAME(sizeof(int_least64_t) == sizeof(long long), "%w64d", "%lld",
-                   (long long)INT64_MIN);
-    NPF_TEST_WSAME(sizeof(uint_least64_t) == sizeof(unsigned long long), "%w64x", "%llx",
-                   (unsigned long long)UINT64_MAX);
+#if INT_LEAST8_MAX == SCHAR_MAX
+    NPF_TEST_WSAME("%w8d", "%hhd", 300);
+    NPF_TEST_WSAME("%w8i", "%hhi", -1);
 #endif
-    NPF_TEST_WSAME(sizeof(int_least64_t) == sizeof(long), "%w64d", "%ld", (long)-12345);
+#if UINT_LEAST8_MAX == UCHAR_MAX
+    NPF_TEST_WSAME("%w8u", "%hhu", 511u);
+    NPF_TEST_WSAME("%w8x", "%hhx", UINT_MAX);
+    NPF_TEST_WSAME("%w8o", "%hho", UINT_MAX);
+#endif
+#if INT_LEAST16_MAX == SHRT_MAX
+    NPF_TEST_WSAME("%w16d", "%hd", 70000);
+#endif
+#if UINT_LEAST16_MAX == USHRT_MAX
+    NPF_TEST_WSAME("%w16u", "%hu", UINT_MAX);
+#endif
+#if INT_LEAST32_MAX == INT_MAX
+    NPF_TEST_WSAME("%w32d", "%d", (int32_t)-12345);
+#endif
+#if INT_FAST8_MAX == SCHAR_MAX
+    NPF_TEST_WSAME("%wf8d", "%hhd", 300);
+#endif
+#if INT_FAST8_MAX == INT_MAX
+    NPF_TEST_WSAME("%wf8d", "%d", 300);
+#endif
+#if INT_FAST16_MAX == INT_MAX
+    NPF_TEST_WSAME("%wf16d", "%d", 70000);
+#endif
+#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
+#if INT_LEAST64_MAX == LLONG_MAX
+    NPF_TEST_WSAME("%w64d", "%lld", (long long)INT64_MIN);
+#endif
+#if UINT_LEAST64_MAX == ULLONG_MAX
+    NPF_TEST_WSAME("%w64x", "%llx", (unsigned long long)UINT64_MAX);
+#endif
+#endif
+#if INT_LEAST64_MAX == LONG_MAX
+    NPF_TEST_WSAME("%w64d", "%ld", (long)-12345);
+#endif
 #undef NPF_TEST_WSAME
 
     /* Flags, field width and precision all apply as usual. */

--- a/tests/gen_tests.py
+++ b/tests/gen_tests.py
@@ -310,7 +310,7 @@ def write_compile_commands(
         "/nologo",
         "/Os",
         "/W4",
-        "/WX",
+        "/WX",  # MSVC's -Werror; build.py holds the same policy for its own targets.
         "/Zc:preprocessor",
         # Narrowing a constant is the whole point of the truncation tests.
         "/wd4310",


### PR DESCRIPTION
`build.bat` under Visual Studio 2022 stops on `error C2220` partway through the conformance suite. 32 lines in `tests/conformance.c` each raise **C4127**, "conditional expression is constant", and that build has carried `/WX` for a long time.

CI never saw it: the `windows-latest` runner is on **Visual Studio 2026** (`v18.9.1`), whose front end no longer reports C4127 for these. So `main` is green on the runner and broken on a 2022 desktop.

## The warnings

Two macros were the whole of it. Each wrapped its cases in a runtime `if` over a `sizeof` comparison the compiler folds away:

```c
if (sizeof(type) <= sizeof(int)) { ... }                    /* NPF_TEST_WPROMO */
if (sizeof(int_least8_t) == sizeof(signed char)) { ... }    /* NPF_TEST_WSAME  */
```

C has no `if constexpr` to mark that as deliberate, so the guards move to the preprocessor, which answers the same questions from the type maxima `<stdint.h>` and `<limits.h>` already publish:

- a signed type is no wider than `int` exactly when its maximum fits in `INT_MAX`
- two integer types of one signedness hold the same values exactly when their maxima match — which is the property these cases actually rest on, more directly than `sizeof` equality does

Grouping cases under `#if` is what the rest of that section already does. Both macros lose a parameter and a nesting level as a result.

## The policy

`/WX` is MSVC's `-Werror`, and three of the four compile-only targets — `npf_static`, `use_npf_directly`, `wrap_npf` — were building at the **default** warning level, so nothing they said could fail the build. They now carry the same `/W4 /WX` set as the unit and conformance builds, hoisted into one `_CL_WARN_FLAGS` so the policy lives in a single place.

All three were already clean at `/W4`. A survey run with `/WX` off across the whole matrix found C4127 to be the **only** warning the entire Windows build emits — 6208 of them, all from those 32 lines.

## Verification

VS 2022 `19.44.35228`, full 2532-combo matrix, no shard:

| config | before | after |
|---|---|---|
| Release / x64 | `error C2220`, exit 1 | clean, exit 0 |
| Release / x86 | — | clean, exit 0 |
| Debug / x64 | — | clean, exit 0 |

All three report `PASSED: 3642306 assertions across 5064 objects` — the same count the green VS 2026 CI run reports, so the `#if` guards select exactly what the runtime guards used to and no coverage was traded away. `clang` also compiles the file clean under the Makefile's `-Wall -Wextra -Wundef -Werror` in both C17 and C++20; `-Wundef` confirms every macro in the new `#if` lines is actually defined.

`nanoprintf.h` is untouched, so there is no code-size impact — cortex-m0/m4 `-Os` output is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
