### PR TITLE
build: move to envy 0.2.5

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -15,9 +15,9 @@
   ],
   "runtime.version": "Lua 5.4",
   "workspace.library": [
-    "build\/envy-cache\/envy\/0.2.3",
-    "~\/Library\/Caches\/envy\/envy\/0.2.3",
-    "~\/.cache\/envy\/envy\/0.2.3",
-    "${env:USERPROFILE}\/AppData\/Local\/envy\/envy\/0.2.3"
+    "build\/envy-cache\/envy\/0.2.5",
+    "~\/Library\/Caches\/envy\/envy\/0.2.5",
+    "~\/.cache\/envy\/envy\/0.2.5",
+    "${env:USERPROFILE}\/AppData\/Local\/envy\/envy\/0.2.5"
   ]
 }

--- a/bin/envy
+++ b/bin/envy
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 ENVY_DEFAULT_MIRROR="https://github.com/envy-package-manager/envy/releases/download"
 ENVY_LATEST_URL="https://github.com/envy-package-manager/envy/releases/latest"
 ENVY_ENV_MIRROR="${ENVY_MIRROR:-}"
-ENVY_FALLBACK_VERSION="0.2.3"
+ENVY_FALLBACK_VERSION="0.2.5"
 ENVY_MIN_DIRECTIVE_VERSION="0.2.0"
 
 resolve_script_dir() {

--- a/bin/envy.bat
+++ b/bin/envy.bat
@@ -6,7 +6,7 @@ set "ENVY_DEFAULT_MIRROR=https://github.com/envy-package-manager/envy/releases/d
 set "ENVY_LATEST_URL=https://github.com/envy-package-manager/envy/releases/latest"
 set "ENVY_ENV_MIRROR="
 if defined ENVY_MIRROR set "ENVY_ENV_MIRROR=%ENVY_MIRROR%"
-set "ENVY_FALLBACK_VERSION=0.2.3"
+set "ENVY_FALLBACK_VERSION=0.2.5"
 set "ENVY_MIN_DIRECTIVE_VERSION=0.2.0"
 
 set "ENVY_MANIFEST="

--- a/envy.lua
+++ b/envy.lua
@@ -4,8 +4,8 @@
 -- ENVY_CACHE_ROOT opts into a shared cache.
 
 -- @envy schema "1"
--- @envy version "0.2.3"
--- @envy sha256sums "e1941f91fa9ff5412537ae1a6ac94c87710256978253e37a2e327a810e2bc5c5"
+-- @envy version "0.2.5"
+-- @envy sha256sums "8f46bb9295d17ad29787a3e770f313e360501c4bb5eaf29cdd30cf36c86d4647"
 -- @envy bin "bin"
 -- @envy cache-local "build/envy-cache"
 -- @envy deploy "true"


### PR DESCRIPTION
Bumps the pinned envy toolchain from 0.2.3 to 0.2.5 via `./bin/envy use 0.2.5` followed by `./bin/envy sync --platform all`.

Changes are all generated: the pinned version and sha256sums in `envy.lua`, the `ENVY_FALLBACK_VERSION` in both bootstrap scripts, and the version-stamped library paths in `.luarc.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)