### PR TITLE
build: move to envy 0.3.0

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,42 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# nanoprintf pins its whole toolchain (CPython, doctest, ruff) with envy, and
+# envy.lua's `@envy cache-local "build/envy-cache"` directive keeps those packages
+# inside the workspace. That's the right default for a lone clone, but it means
+# every Conductor worktree re-downloads ~250MB of CPython from scratch. If you're
+# using Conductor to create multiple nanoprintf worktrees, it's worth using the
+# shared cache to amortize that setup cost: the first workspace pays the download
+# and every later one is nearly free.
+#
+# `envy cache --shared` writes the gitignored .envy-cache-shared marker, which
+# outranks the manifest's cache-local directive. `envy install` is exactly what the
+# Makefile runs up front, so this only warms the cache -- it never rewrites the
+# committed shims in bin/.
+setup = """
+./bin/envy cache --shared
+./bin/envy install
+"""
+
+# Each workspace builds into its own build/ tree and nothing binds a port or a
+# daemon, so overlapping runs are safe; the only cost is CPU contention between
+# two `make -j12` matrices.
+run_mode = "concurrent"
+
+# The worktree goes away on archive; this just reclaims the multi-GB build tree
+# early. `make clean` skips the envy bootstrap and spares build/envy-cache.
+archive = "make clean"
+
+[scripts.run.unit]
+command = "make -j12 unit"
+default = true
+icon = "test-tube"
+
+# The full conformance matrix. Slow -- hundreds of flag combinations.
+[scripts.run.tests]
+command = "make -j12"
+icon = "layers"
+
+[scripts.run.lint]
+command = "./bin/ruff check build.py release.py tests/gen_tests.py tests/gen_eg_tests.py tests/size_report.py tests/avr_int16.py && ./bin/python3 release.py --check"
+icon = "check-check"

--- a/.luarc.json
+++ b/.luarc.json
@@ -15,9 +15,9 @@
   ],
   "runtime.version": "Lua 5.4",
   "workspace.library": [
-    "build\/envy-cache\/envy\/0.2.5",
-    "~\/Library\/Caches\/envy\/envy\/0.2.5",
-    "~\/.cache\/envy\/envy\/0.2.5",
-    "${env:USERPROFILE}\/AppData\/Local\/envy\/envy\/0.2.5"
+    "build\/envy-cache\/envy\/0.3.0",
+    "~\/Library\/Caches\/envy\/envy\/0.3.0",
+    "~\/.cache\/envy\/envy\/0.3.0",
+    "${env:USERPROFILE}\/AppData\/Local\/envy\/envy\/0.3.0"
   ]
 }

--- a/bin/envy
+++ b/bin/envy
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 ENVY_DEFAULT_MIRROR="https://github.com/envy-package-manager/envy/releases/download"
 ENVY_LATEST_URL="https://github.com/envy-package-manager/envy/releases/latest"
 ENVY_ENV_MIRROR="${ENVY_MIRROR:-}"
-ENVY_FALLBACK_VERSION="0.2.5"
+ENVY_FALLBACK_VERSION="0.3.0"
 ENVY_MIN_DIRECTIVE_VERSION="0.2.0"
 
 resolve_script_dir() {

--- a/bin/envy.bat
+++ b/bin/envy.bat
@@ -6,7 +6,7 @@ set "ENVY_DEFAULT_MIRROR=https://github.com/envy-package-manager/envy/releases/d
 set "ENVY_LATEST_URL=https://github.com/envy-package-manager/envy/releases/latest"
 set "ENVY_ENV_MIRROR="
 if defined ENVY_MIRROR set "ENVY_ENV_MIRROR=%ENVY_MIRROR%"
-set "ENVY_FALLBACK_VERSION=0.2.5"
+set "ENVY_FALLBACK_VERSION=0.3.0"
 set "ENVY_MIN_DIRECTIVE_VERSION=0.2.0"
 
 set "ENVY_MANIFEST="

--- a/envy.lua
+++ b/envy.lua
@@ -4,8 +4,8 @@
 -- ENVY_CACHE_ROOT opts into a shared cache.
 
 -- @envy schema "1"
--- @envy version "0.2.5"
--- @envy sha256sums "8f46bb9295d17ad29787a3e770f313e360501c4bb5eaf29cdd30cf36c86d4647"
+-- @envy version "0.3.0"
+-- @envy sha256sums "c10e6a029cb0b15c2ab342f234a9ce7a50e0b28adb1795cf81cb2f0c4e66788f"
 -- @envy bin "bin"
 -- @envy cache-local "build/envy-cache"
 -- @envy deploy "true"


### PR DESCRIPTION
`envy use 0.3.0` + `envy sync --platform all`.

- `envy.lua`: `@envy version` and `@envy sha256sums` bumped to 0.3.0.
- `bin/envy`, `bin/envy.bat`: restamped `ENVY_FALLBACK_VERSION`.
- `.luarc.json`: types paths repointed at `envy/0.3.0`.

No other repo references to 0.2.5.

Also adds `.conductor/settings.toml`, a shared Conductor config. Its setup script runs
`envy cache --shared` so each new worktree uses the user-wide package cache instead of
re-downloading the pinned toolchain into `build/envy-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)